### PR TITLE
Feat(NFT): Add a sort by Account | Collection button

### DIFF
--- a/src/components/NFTsBySort.tsx
+++ b/src/components/NFTsBySort.tsx
@@ -1,0 +1,55 @@
+import { NftCard } from '@talisman-components/nft'
+import { device } from '@util/breakpoints'
+import styled from 'styled-components'
+
+const NFTsGridWrapper = styled.div`
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: 1fr;
+  margin-bottom: 3rem;
+
+  @media ${device.md} {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @media ${device.lg} {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  @media ${device.xl} {
+    grid-template-columns: repeat(4, 1fr);
+  }
+`
+
+export interface NFTsBySortProps {
+  sortedNfts: any[]
+}
+
+const NFTsBySort = ({ sortedNfts }: NFTsBySortProps) => {
+  if (!sortedNfts) {
+    return <h3>No sorted NFTs found!</h3>
+  }
+
+  const renderCollection = Object.keys(sortedNfts).map((collectionName: any) => {
+    return (
+      <div key={collectionName}>
+      <h2>{collectionName}</h2>
+
+      <NFTsGridWrapper>
+        {sortedNfts[collectionName].map((nft: any) => (
+            <NftCard key={nft.id} nft={nft} />
+          )
+        )}
+      </NFTsGridWrapper>
+    </div>
+    )
+  })
+
+  return (
+    <div>
+      {renderCollection}
+    </div>
+  )
+}
+
+export { NFTsGridWrapper, NFTsBySort }

--- a/src/components/NFTsBySort.tsx
+++ b/src/components/NFTsBySort.tsx
@@ -30,28 +30,23 @@ const NFTsBySort = ({ sortedNfts }: NFTsBySortProps) => {
     return <h3>No sorted NFTs found!</h3>
   }
 
-  console.log(typeof sortedNfts)
+  const renderCollection = Object.keys(sortedNfts)
+    .sort()
+    .map((collectionName: any) => {
+      return (
+        <div key={collectionName}>
+          <h2>{collectionName}</h2>
 
-  const renderCollection = Object.keys(sortedNfts).sort().map((collectionName: any) => {
-    return (
-      <div key={collectionName}>
-      <h2>{collectionName}</h2>
+          <NFTsGridWrapper>
+            {sortedNfts[collectionName].map((nft: any) => (
+              <NftCard key={nft.id} nft={nft} />
+            ))}
+          </NFTsGridWrapper>
+        </div>
+      )
+    })
 
-      <NFTsGridWrapper>
-        {sortedNfts[collectionName].map((nft: any) => (
-            <NftCard key={nft.id} nft={nft} />
-          )
-        )}
-      </NFTsGridWrapper>
-    </div>
-    )
-  })
-
-  return (
-    <div>
-      {renderCollection}
-    </div>
-  )
+  return <>{renderCollection}</>
 }
 
 export { NFTsGridWrapper, NFTsBySort }

--- a/src/components/NFTsBySort.tsx
+++ b/src/components/NFTsBySort.tsx
@@ -30,7 +30,9 @@ const NFTsBySort = ({ sortedNfts }: NFTsBySortProps) => {
     return <h3>No sorted NFTs found!</h3>
   }
 
-  const renderCollection = Object.keys(sortedNfts).map((collectionName: any) => {
+  console.log(typeof sortedNfts)
+
+  const renderCollection = Object.keys(sortedNfts).sort().map((collectionName: any) => {
     return (
       <div key={collectionName}>
       <h2>{collectionName}</h2>

--- a/src/components/SortButtons.tsx
+++ b/src/components/SortButtons.tsx
@@ -1,0 +1,35 @@
+import styled from 'styled-components'
+import Button from '@components/Button'
+
+const GroupSortsButton = styled.div`
+  display: flex;
+  padding: 0px 20px;
+  align-items: center;
+  margin-button: 40px;
+  justify-content: center;
+  gap: 10px;
+  color: black;
+`
+
+const SortButton = styled(Button)`
+  color: white;
+
+  ${({ isSelected, theme }) =>
+    !!isSelected &&
+    `
+      background: rgb(${theme?.primary});
+      color: rgb(${theme?.background});
+    `
+  }
+`
+
+const SortButtons = ({ setSortByAccount, setSortByCollection, sortBy }: any) => {
+  return (
+    <GroupSortsButton>
+      <SortButton isSelected={sortBy === 'account'} onClick={setSortByAccount}>Account</SortButton>
+      <SortButton isSelected={sortBy === 'collection'} onClick={setSortByCollection}>Collection</SortButton>
+    </GroupSortsButton>
+  )
+}
+
+export default SortButtons

--- a/src/components/SortButtons.tsx
+++ b/src/components/SortButtons.tsx
@@ -1,34 +1,37 @@
+import { Field } from '@components'
 import styled from 'styled-components'
-import Button from '@components/Button'
 
-const GroupSortsButton = styled.div`
+const SortButtonsWrapper = styled.div`
   display: flex;
   padding: 0px 20px;
-  align-items: center;
-  margin-button: 40px;
   justify-content: center;
   gap: 10px;
-  color: black;
+  color: var(--color-primary);
 `
 
-const SortButton = styled(Button)`
-  color: white;
+const sortOptions = [
+  {
+    key: 'account',
+    value: 'Account',
+  },
+  {
+    key: 'collection',
+    value: 'Collection',
+  },
+]
 
-  ${({ isSelected, theme }) =>
-    !!isSelected &&
-    `
-      background: rgb(${theme?.primary});
-      color: rgb(${theme?.background});
-    `
-  }
-`
-
-const SortButtons = ({ setSortByAccount, setSortByCollection, sortBy }: any) => {
+const SortButtons = ({ sortValue, setSortBy, setSortTrigger }: any) => {
   return (
-    <GroupSortsButton>
-      <SortButton isSelected={sortBy === 'account'} onClick={setSortByAccount}>Account</SortButton>
-      <SortButton isSelected={sortBy === 'collection'} onClick={setSortByCollection}>Collection</SortButton>
-    </GroupSortsButton>
+    <SortButtonsWrapper>
+      <Field.RadioGroup
+        value={sortValue}
+        onChange={(value: any) => {
+          setSortBy(value)
+          setSortTrigger(true)
+        }}
+        options={sortOptions}
+      />
+    </SortButtonsWrapper>
   )
 }
 

--- a/src/routes/NFTsPage.tsx
+++ b/src/routes/NFTsPage.tsx
@@ -52,6 +52,7 @@ const NFTGrid = styled(({ className = '', account, setTotalNfts }: AccountProps)
   const { nfts } = useNftsByAddress(address as string)
 
   useEffect(() => {
+    // Needs to add check if this is a function, or else TS will be angry
     if(setTotalNfts === false || typeof setTotalNfts !== 'function') {
       return;
     }

--- a/src/routes/NFTsPage.tsx
+++ b/src/routes/NFTsPage.tsx
@@ -97,13 +97,13 @@ const NFTGrid = styled(({ className = '', account, setTotalNfts }: AccountProps)
   }
 `
 
-export type SoryByValue = 'account' | 'collection'
+export type SortByValue = 'account' | 'collection'
 
 const NFTsPage = styled(({ className }) => {
   const { accounts } = useExtensionAutoConnect()
   const [totalNfts, setTotalNfts] = useState<any[] | undefined>([])
   const [sortTrigger, setSortTrigger] = useState(false)
-  const [sortBy, setSortBy] = useState<SoryByValue>('account')
+  const [sortBy, setSortBy] = useState<SortByValue>('account')
 
   const updateTotalNfts = (nfts: any) => {
     if (!nfts) return

--- a/src/routes/NFTsPage.tsx
+++ b/src/routes/NFTsPage.tsx
@@ -1,16 +1,14 @@
+import { ExtensionStatusGate, PanelSection } from '@components'
+import NFTsByAddress from '@components/NFTsByAddress'
+import { NFTsBySort, NFTsGridWrapper } from '@components/NFTsBySort'
+import SortButtons from '@components/SortButtons'
+import { Account as IAccount, useExtensionAutoConnect } from '@libs/talisman'
+import Identicon from '@polkadot/react-identicon'
+import { useNftsByAddress } from '@talisman-components/nft'
+import { device } from '@util/breakpoints'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
-
-import { device } from '@util/breakpoints'
-import { Account as IAccount, useExtensionAutoConnect } from '@libs/talisman'
-
-import Identicon from '@polkadot/react-identicon'
-import { useNftsByAddress } from '@talisman-components/nft'
-import { NFTsGridWrapper, NFTsBySort } from '@components/NFTsBySort'
-import { ExtensionStatusGate, PanelSection } from '@components'
-import NFTsByAddress from '@components/NFTsByAddress'
-import SortButtons from '@components/SortButtons'
 
 interface AccountProps {
   className?: string
@@ -53,12 +51,12 @@ const NFTGrid = styled(({ className = '', account, setTotalNfts }: AccountProps)
 
   useEffect(() => {
     // Needs to add check if this is a function, or else TS will be angry
-    if(setTotalNfts === false || typeof setTotalNfts !== 'function') {
-      return;
+    if (setTotalNfts === false || typeof setTotalNfts !== 'function') {
+      return
     }
     setTotalNfts(nfts)
   }, [nfts])
-  
+
   if (!nfts?.length) {
     return null
   }
@@ -99,32 +97,19 @@ const NFTGrid = styled(({ className = '', account, setTotalNfts }: AccountProps)
   }
 `
 
-export enum SoryByValue {
-  ACCOUNT = 'account',
-  COLLECTION = 'collection'
-}
+export type SoryByValue = 'account' | 'collection'
 
 const NFTsPage = styled(({ className }) => {
   const { accounts } = useExtensionAutoConnect()
   const [totalNfts, setTotalNfts] = useState<any[] | undefined>([])
   const [sortTrigger, setSortTrigger] = useState(false)
-  const [sortBy, setSortBy] = useState<SoryByValue>(SoryByValue.ACCOUNT)
+  const [sortBy, setSortBy] = useState<SoryByValue>('account')
 
   const updateTotalNfts = (nfts: any) => {
-    if(!nfts) return;
+    if (!nfts) return
     setTotalNfts((prevState: any) => {
       return [...prevState, ...nfts]
     })
-  }
-
-  const setSortByAccount = () => {
-    setSortBy(SoryByValue.ACCOUNT)
-  }
-
-  const setSortByCollection = () => {
-    setSortBy(SoryByValue.COLLECTION)
-    // this is needed to prevent the component from re-adding states during the re-render
-    setSortTrigger(true);
   }
 
   // Store the collections in an object of arrays
@@ -150,24 +135,15 @@ const NFTsPage = styled(({ className }) => {
     <section className={className}>
       <h1>NFTs</h1>
       <ExtensionStatusGate unavailable={<ExtensionUnavailable />}>
-        <SortButtons
-          setSortByAccount={setSortByAccount}
-          setSortByCollection={setSortByCollection}
-          sortBy={sortBy}
-        />
-        
-        <div className="all-nft-grids">
-          {sortBy === 'collection' && (
-            <NFTsBySort sortedNfts={sortNFtsByCollection(totalNfts)} />
-          )}
+        <SortButtons sortValue={sortBy} setSortBy={setSortBy} setSortTrigger={setSortTrigger} />
 
-          {sortBy === 'account' && accounts?.map(account => (
-            <NFTGrid
-              key={account.address}
-              account={account}
-              setTotalNfts={!sortTrigger && updateTotalNfts}
-            />
-          ))}
+        <div className="all-nft-grids">
+          {sortBy === 'collection' && <NFTsBySort sortedNfts={sortNFtsByCollection(totalNfts)} />}
+
+          {sortBy === 'account' &&
+            accounts?.map(account => (
+              <NFTGrid key={account.address} account={account} setTotalNfts={!sortTrigger && updateTotalNfts} />
+            ))}
         </div>
       </ExtensionStatusGate>
     </section>

--- a/src/routes/NFTsPage.tsx
+++ b/src/routes/NFTsPage.tsx
@@ -127,8 +127,7 @@ const NFTsPage = styled(({ className }) => {
     setSortTrigger(true);
   }
 
-  // Once we grab all NFTs, in this case, it's an Array<{}>
-  // We use this function to store them in its respective category
+  // Store the collections in an object of arrays
   const sortNFtsByCollection = (nfts: any) => {
     const getAllNFtsCollections = nfts.reduce((collectionAccumlator: any, nft: any) => {
       // Get collection name


### PR DESCRIPTION
## Desc

- Added 2 buttons to sort the NFTs by account and collection.
- By default, the page will display the items sorted by account.
- If Collection is clicked, it will sort the items and display them by collection.

## Changes

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
      <p>
        <img src="https://user-images.githubusercontent.com/12386682/158114847-68a4dc35-7f2c-4707-ba96-5a5d2f7b0336.png" />
      </p>
</td>
      <td>
    <img src="https://user-images.githubusercontent.com/12386682/158114899-3998098c-f824-416f-bbbb-995993bd624c.png" />
  </td>
  </tr>
</table>
<p align='center'>
<img src="https://user-images.githubusercontent.com/12386682/158120762-570b06a6-b3f7-47f6-ba4b-4e3db98b2d9a.gif" width="500px" />
</p>

## Limitations

### Retrieving all NFTs
As far as I'm aware, the only way to get NFTs is by calling `useNFTsByAddress`, and you need to loop through all wallets to get all NFTs.
- This is tough when you're dealing with a feature like sorting where you need to have the total amount of items before you do the sorting. E.g. `total items > sort them > display sorted items`
- Also hooks will throw a hissy fit (breaking the rules of hooks) if you try to be a smart ass and wrap it in a utility function inside a functional component. (*I was that smart ass*)

Ideally, we want to be able to do something like `useNFTsByAddresses`. This way, you only need to feed the API all the wallets at once and retrieve all of the NFTs.

### Workaround-*ish*
- To get all NFTs on the NFTsPage component, I added a hook to accumulate NFTs as the page tries to render the NFTs from each account.
- Once it's done rendering (the accumulating should be done as well), we now have all the NFTs to do the sorting.
- The negative side is that this relies entirely on the initial rendering to complete, if it isn't, then we'll be looking at some unexpected behavior.
  - On Mr. Brideside, we're taking advantage of the initial render and collecting all NFTs, so we can use them to sort and display in a collection format without having to do another API call.

## Improvements

### Typescript

There are a few *cheeky* types `any` in this PR, which is not ideal since that defeats the purpose of using TS. I strongly recommend that they need to be typed out before this PR is merged into prod.

### Generic components

In NFTsPage, we're using `NFTGrid` and `NFTsBySort` which are very similar.
- We could potentially create a reusable component called `<NFTSection />`  that takes `account` or `collection` prop.
  - `account` prop for displaying `NFTGrid`
  - `collection` prop for displaying `NFTsBySort`
- This should shrink down the line numbers of the NFTsPage component and make it more readable.

## Bugs

1. `<NFTCard />` component is showing a blank image when trying to render video NFTs.
