### PR TITLE
ci: add missing base branch

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -19,5 +19,5 @@ jobs:
           cache: yarn
 
       - run: yarn install --immutable
-      - run: yarn pretty-quick --check
+      - run: yarn pretty-quick --branch prod --check
       - run: yarn eslint .


### PR DESCRIPTION
since we use a none default branch name `prod`