### PR TITLE
fix: add .yarn and build to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+.yarn
+build


### PR DESCRIPTION
fixes an error we get when we try to commit a new yarn version:

> 🔍  Finding changed files since git revision aac2d13.
> 🎯  Found 95 changed files.
>
> /workspaces/talisman-web/node_modules/prettier/index.js:13704
>     throw error.stack;
>     ^
> Error: prettier-plugin-import-sort:
> No configuration found for file type .cjs
> husky - pre-commit hook exited with code 1 (error)