### PR TITLE
fix: change nom pools available block

### DIFF
--- a/src/domains/nominationPools/hooks/useCountDownToNomsPool.ts
+++ b/src/domains/nominationPools/hooks/useCountDownToNomsPool.ts
@@ -3,7 +3,7 @@ import { useChainState } from '@domains/common/hooks'
 import { BN } from '@polkadot/util'
 import { useRecoilValue } from 'recoil'
 
-const AVAILABLE_AT_BLOCK = new BN(12_721_880)
+const AVAILABLE_AT_BLOCK = new BN(12_722_480)
 
 export const useCountDownToNomsPool = () => {
   const api = useRecoilValue(apiState)


### PR DESCRIPTION
- push "go live" block for nomination pools back 600 blocks (enactment period)