### PR TITLE
refactor: selected accounts state & fallback

### DIFF
--- a/src/domains/accounts/recoils.ts
+++ b/src/domains/accounts/recoils.ts
@@ -42,6 +42,12 @@ export const AccountsWatcher = () => {
   const extension = useRecoilValue(extensionState)
   const setAccounts = useSetRecoilState(accountsState)
 
+  useEffect(() => {
+    if (extension === undefined) {
+      setAccounts([])
+    }
+  }, [extension, setAccounts])
+
   useEffect(() => extension?.accounts.subscribe(setAccounts), [extension?.accounts, setAccounts])
 
   return null

--- a/src/routes/Staking.tsx
+++ b/src/routes/Staking.tsx
@@ -57,21 +57,27 @@ const Statistics = () => {
   const totalStaked = useTokenAmountFromAtomics(
     useMemo(
       () =>
-        poolMembersLoadable.valueMaybe()?.reduce((prev, curr) => prev.add(curr.unwrapOrDefault().points), new BN(0)),
-      [poolMembersLoadable]
+        accounts.length === 0
+          ? new BN(0)
+          : poolMembersLoadable
+              .valueMaybe()
+              ?.reduce((prev, curr) => prev.add(curr.unwrapOrDefault().points), new BN(0)),
+      [accounts.length, poolMembersLoadable]
     )
   )
 
   const totalUnstaking = useTokenAmountFromAtomics(
     useMemo(
       () =>
-        poolMembersLoadable.valueMaybe()?.reduce((prev, curr) => {
-          for (const [_, unbonding] of curr.unwrapOrDefault().unbondingEras.entries()) {
-            prev.iadd(unbonding)
-          }
-          return prev
-        }, new BN(0)),
-      [poolMembersLoadable]
+        accounts.length === 0
+          ? new BN(0)
+          : poolMembersLoadable.valueMaybe()?.reduce((prev, curr) => {
+              for (const [_, unbonding] of curr.unwrapOrDefault().unbondingEras.entries()) {
+                prev.iadd(unbonding)
+              }
+              return prev
+            }, new BN(0)),
+      [accounts.length, poolMembersLoadable]
     )
   )
 

--- a/src/routes/Staking.tsx
+++ b/src/routes/Staking.tsx
@@ -33,7 +33,7 @@ const availableToStakeState = selector({
     const balances = await Promise.all(accounts.map(({ address }) => api.derive.balances.all(address)))
 
     return balances.reduce(
-      (prev, curr) => curr.availableBalance.sub(api.consts.balances.existentialDeposit).add(prev),
+      (prev, curr) => BN.max(new BN(0), curr.availableBalance.sub(api.consts.balances.existentialDeposit)).add(prev),
       new BN(0)
     )
   },


### PR DESCRIPTION
For some of the items here, they will keep on spinning if the user hasn't connected an account, this PR will have them default to 0 instead:

<img width="956" alt="image" src="https://user-images.githubusercontent.com/19813755/199460744-8b337ee3-e463-4511-bc11-324966c9db5f.png">
