### PR TITLE
fix: null error

### DIFF
--- a/src/archetypes/NominationPools/AddStakeDialog.tsx
+++ b/src/archetypes/NominationPools/AddStakeDialog.tsx
@@ -20,7 +20,7 @@ const AddStakeDialog = (props: { account?: string; onDismiss: () => unknown }) =
     if (bondExtraExtrinsic.state === 'loading' && bondExtraExtrinsic.contents?.status.isInBlock) {
       props.onDismiss()
     }
-  }, [bondExtraExtrinsic.contents?.status.isInBlock, bondExtraExtrinsic.state, props])
+  }, [bondExtraExtrinsic.contents?.status?.isInBlock, bondExtraExtrinsic.state, props])
 
   return (
     <BaseAddStakeDialog


### PR DESCRIPTION
ESLint fix suggestion added `unbondExtrinsic.contents?.status.isInBlock`, since `contents` is possibly an error, and is typed as any. ESLint wasn't smart enough to detect that when suggesting the auto complete.