### PR TITLE
style: add gap between toasts & top navigation bar

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -57,7 +57,7 @@ const App: React.FC = () => (
                       <RouterProvider router={router} />
                     </MoonbeamContributors.PopupProvider>
                   </ModalProvider>
-                  <Toaster position="top-right" containerStyle={{ top: '6rem' }}>
+                  <Toaster position="top-right" containerStyle={{ top: '6.4rem' }}>
                     {t => <ToastBar toast={t} />}
                   </Toaster>
                 </Suspense>


### PR DESCRIPTION
Needed since top navigation bar stick to top of view port now

<img width="459" alt="image" src="https://user-images.githubusercontent.com/19813755/200995853-1f5676ae-2f13-4800-b0dd-9d7dde8ccaf5.png">
