### PR TITLE
fix: pool status indicator

### DIFF
--- a/apps/web/src/archetypes/NominationPools/Stakings.tsx
+++ b/apps/web/src/archetypes/NominationPools/Stakings.tsx
@@ -6,6 +6,7 @@ import PoolStake, { PoolStakeList } from '@components/recipes/PoolStake/PoolStak
 import { PoolStatus } from '@components/recipes/PoolStatusIndicator'
 import { selectedPolkadotAccountsState } from '@domains/accounts/recoils'
 import { createAccounts } from '@domains/nominationPools/utils'
+import { Maybe } from '@util/monads'
 import { useCallback, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { constSelector, useRecoilValueLoadable, useRecoilValue_TRANSITION_SUPPORT_UNSTABLE, waitForAll } from 'recoil'
@@ -54,7 +55,7 @@ const Stakings = () => {
   )
 
   const eraStakers = useMemo(
-    () => new Set(eraStakersLoadable.valueMaybe()?.map(x => x[0].args[1].toHuman())),
+    () => Maybe.of(eraStakersLoadable.valueMaybe()).mapOrUndefined(x => new Set(x.map(x => x[0].args[1].toHuman()))),
     [eraStakersLoadable]
   )
 

--- a/apps/web/src/components/atoms/Tooltip/Tooltip.tsx
+++ b/apps/web/src/components/atoms/Tooltip/Tooltip.tsx
@@ -58,6 +58,7 @@ const Tooltip = (props: TooltipProps) => {
               backgroundColor: theme.color.foregroundVariant,
               padding: '0.6rem',
               borderRadius: '0.4rem',
+              zIndex: 50,
             }}
             style={{ opacity: mouseOver ? 1 : 0, top: y, left: x }}
           >

--- a/apps/web/src/components/recipes/PoolStatusIndicator.tsx
+++ b/apps/web/src/components/recipes/PoolStatusIndicator.tsx
@@ -1,7 +1,7 @@
 import StatusIndicator, { StatusIndicatorProps } from '@components/atoms/StatusIndicator'
 import { useMemo } from 'react'
 
-export type PoolStatus = 'earning_rewards' | 'waiting' | 'not_nominating'
+export type PoolStatus = 'earning_rewards' | 'waiting' | 'not_nominating' | undefined
 
 export type PoolStatusIndicatorProps = Omit<StatusIndicatorProps, 'status'> & {
   status?: PoolStatus


### PR DESCRIPTION
# Fixed

- Tool tip was hidden on staking input
- On portfolio page, initial status was `not_earning_rewards`