### PR TITLE
fix: temporarily switched to v0a tx history indexer

### DIFF
--- a/apps/web/netlify.toml
+++ b/apps/web/netlify.toml
@@ -1,16 +1,16 @@
 [context.production.environment]
     REACT_APP_APPLICATION_NAME = "Talisman"
     REACT_APP_RAMP_API_KEY = "auu2eae53pvp6pboq7oft9dxh5fznhwq7h6tpaxq"
-    REACT_APP_TX_HISTORY_INDEXER = "https://squid.subsquid.io/tx-history/v/v0b/graphql"
+    REACT_APP_TX_HISTORY_INDEXER = "https://squid.subsquid.io/tx-history/v/v0a/graphql"
 
 [context.staging.environment]
     REACT_APP_APPLICATION_NAME = "Talisman Staging"
     REACT_APP_RAMP_API_KEY = "y3asdf899w5xcnxguzas93uwg86dcxz54xaogyt9"
     REACT_APP_RAMP_URL = "https://ri-widget-staging.firebaseapp.com"
-    REACT_APP_TX_HISTORY_INDEXER = "https://squid.subsquid.io/tx-history/v/v0b/graphql"
+    REACT_APP_TX_HISTORY_INDEXER = "https://squid.subsquid.io/tx-history/v/v0a/graphql"
 
 [context.deploy-preview.environment]
     REACT_APP_APPLICATION_NAME = "Talisman PR Preview"
     REACT_APP_RAMP_API_KEY = "y3asdf899w5xcnxguzas93uwg86dcxz54xaogyt9"
     REACT_APP_RAMP_URL = "https://ri-widget-staging.firebaseapp.com"
-    REACT_APP_TX_HISTORY_INDEXER = "https://squid.subsquid.io/tx-history/v/v0b/graphql"
+    REACT_APP_TX_HISTORY_INDEXER = "https://squid.subsquid.io/tx-history/v/v0a/graphql"


### PR DESCRIPTION
The v0b indexer is currently offline (ran out of disk space - we're waiting on a request to add more), so we've spun up another one (v0a) which is only indexing the past month-ish of moonbeam.