### PR TITLE
fix: allow pjs and subwallet users to connect even if Talisman is not installed

### DIFF
--- a/apps/web/src/components/WalletNavConnector.tsx
+++ b/apps/web/src/components/WalletNavConnector.tsx
@@ -1,6 +1,6 @@
 import { Account } from '@archetypes'
 import { DAPP_NAME, useExtension } from '@libs/talisman'
-import { useTalismanInstalled } from '@libs/talisman/useIsTalismanInstalled'
+import { useIsAnyWalletInstalled } from '@libs/talisman/useIsAnyWalletInstalled'
 import { WalletSelect } from '@talismn/connect-components'
 import getDownloadLink from '@util/getDownloadLink'
 import { useTranslation } from 'react-i18next'
@@ -10,12 +10,12 @@ import Button from './atoms/Button'
 export const WalletNavConnector = () => {
   const { t } = useTranslation('nav')
 
-  const isTalismanInstalled = useTalismanInstalled()
+  const isAnyWalletInstalled = useIsAnyWalletInstalled()
   const downloadLink = getDownloadLink()
   const { status: extensionStatus } = useExtension()
 
   if (extensionStatus === 'UNAVAILABLE')
-    return isTalismanInstalled ? (
+    return isAnyWalletInstalled ? (
       <WalletSelect dappName={DAPP_NAME} triggerComponent={<Button>{t('Connect')}</Button>} />
     ) : (
       <a href={downloadLink} target="_blank" rel="noopener noreferrer">

--- a/apps/web/src/libs/talisman/useIsAnyWalletInstalled.ts
+++ b/apps/web/src/libs/talisman/useIsAnyWalletInstalled.ts
@@ -1,0 +1,12 @@
+import { getWallets } from '@talismn/connect-wallets'
+import { useEffect, useState } from 'react'
+
+export function useIsAnyWalletInstalled() {
+  const [isAnyWalletInstalled, setIsAnyWalletInstalled] = useState<boolean>()
+  useEffect(() => {
+    const wallets = getWallets()
+    const installedWallets = wallets.filter(w => w.installed)
+    setIsAnyWalletInstalled(installedWallets.length > 0)
+  }, [])
+  return isAnyWalletInstalled
+}


### PR DESCRIPTION
Fixed our Connect/Install button to allow user to connect with their existing wallet if they have one.

It was redirecting users to the talisman install page if it wasn't installed, preventing users to connect with polkadotjs or subwallet
It will now only redirect if there is no wallet installed, and show the existing wallet select modal otherwise

Note : this is a quick-fix solution, only 3 wallets are currently supported. 