### PR TITLE
chore: rename polkadot to substrate

### DIFF
--- a/apps/web/src/archetypes/NominationPools/OwnPools.tsx
+++ b/apps/web/src/archetypes/NominationPools/OwnPools.tsx
@@ -1,6 +1,6 @@
 import Text from '@components/atoms/Text'
 import PoolStake, { PoolStakeList } from '@components/recipes/PoolStake/PoolStake'
-import { selectedPolkadotAccountsState } from '@domains/accounts/recoils'
+import { selectedSubstrateAccountsState } from '@domains/accounts/recoils'
 import { useChainState } from '@domains/common/hooks'
 import { useTotalStaked } from '@domains/staking/hooks'
 import { useTheme } from '@emotion/react'
@@ -13,7 +13,7 @@ import ValidatorStakings from './ValidatorStakings'
 import ValidatorUnstakings from './ValidatorUnstakings'
 
 const UnstakingHeader = () => {
-  const accounts = useRecoilValue(selectedPolkadotAccountsState)
+  const accounts = useRecoilValue(selectedSubstrateAccountsState)
 
   const poolMembersLoadable = useChainState(
     'query',

--- a/apps/web/src/archetypes/NominationPools/Stakings.tsx
+++ b/apps/web/src/archetypes/NominationPools/Stakings.tsx
@@ -4,7 +4,7 @@ import Text from '@components/atoms/Text'
 import HiddenDetails from '@components/molecules/HiddenDetails'
 import PoolStake, { PoolStakeList } from '@components/recipes/PoolStake/PoolStake'
 import { PoolStatus } from '@components/recipes/PoolStatusIndicator'
-import { selectedPolkadotAccountsState } from '@domains/accounts/recoils'
+import { selectedSubstrateAccountsState } from '@domains/accounts/recoils'
 import { createAccounts } from '@domains/nominationPools/utils'
 import { Maybe } from '@util/monads'
 import { useMemo } from 'react'
@@ -18,7 +18,7 @@ import PoolStakeItem from './PoolStakeItem'
 
 const Stakings = () => {
   const [api, pendingRewards, accounts] = useRecoilValue_TRANSITION_SUPPORT_UNSTABLE(
-    waitForAll([apiState, allPendingPoolRewardsState, selectedPolkadotAccountsState])
+    waitForAll([apiState, allPendingPoolRewardsState, selectedSubstrateAccountsState])
   )
 
   const poolMembersLoadable = useChainState(

--- a/apps/web/src/archetypes/NominationPools/Unstakings.tsx
+++ b/apps/web/src/archetypes/NominationPools/Unstakings.tsx
@@ -1,5 +1,5 @@
 import PoolUnstake, { PoolUnstakeList } from '@components/recipes/PoolUnstake'
-import { selectedPolkadotAccountsState } from '@domains/accounts/recoils'
+import { selectedSubstrateAccountsState } from '@domains/accounts/recoils'
 import { erasToMilliseconds } from '@domains/common/utils'
 import { usePoolUnlocking } from '@domains/nominationPools/hooks/usePoolUnlocking'
 import { createAccounts } from '@domains/nominationPools/utils'
@@ -18,7 +18,7 @@ const Unstakings = (props: { account?: string; showHeader?: boolean; compact?: b
   const sessionProgressLoadable = useChainState('derive', 'session', 'progress', [])
 
   const [api, _accounts, decimalFromAtomics, nativeTokenPrice] = useRecoilValue(
-    waitForAll([apiState, selectedPolkadotAccountsState, nativeTokenDecimalState, nativeTokenPriceState('usd')])
+    waitForAll([apiState, selectedSubstrateAccountsState, nativeTokenDecimalState, nativeTokenPriceState('usd')])
   )
 
   const accounts = useMemo(

--- a/apps/web/src/archetypes/NominationPools/ValidatorStakings.tsx
+++ b/apps/web/src/archetypes/NominationPools/ValidatorStakings.tsx
@@ -1,5 +1,5 @@
 import { ValidatorStakeList } from '@components/recipes/ValidatorStake'
-import { selectedPolkadotAccountsState } from '@domains/accounts/recoils'
+import { selectedSubstrateAccountsState } from '@domains/accounts/recoils'
 import { Maybe } from '@util/monads'
 import { useRecoilValue } from 'recoil'
 
@@ -7,7 +7,7 @@ import useChainState from '../../domains/common/hooks/useChainState'
 import ValidatorStakeItem from './ValidatorStakeItem'
 
 const ValidatorStakings = () => {
-  const accounts = useRecoilValue(selectedPolkadotAccountsState)
+  const accounts = useRecoilValue(selectedSubstrateAccountsState)
 
   const activeEra = useChainState('query', 'staking', 'activeEra', []).valueMaybe()
 

--- a/apps/web/src/archetypes/NominationPools/ValidatorUnstakings.tsx
+++ b/apps/web/src/archetypes/NominationPools/ValidatorUnstakings.tsx
@@ -1,5 +1,5 @@
 import PoolUnstake, { ValidatorUnstakeList } from '@components/recipes/PoolUnstake'
-import { selectedPolkadotAccountsState } from '@domains/accounts/recoils'
+import { selectedSubstrateAccountsState } from '@domains/accounts/recoils'
 import { erasToMilliseconds } from '@domains/common/utils'
 import { addMilliseconds, formatDistanceToNow } from 'date-fns'
 import { useRecoilValue, waitForAll } from 'recoil'
@@ -14,7 +14,7 @@ const ValidatorUnstakings = () => {
   const sessionProgressLoadable = useChainState('derive', 'session', 'progress', [])
 
   const [api, accounts, decimal, nativeTokenPrice] = useRecoilValue(
-    waitForAll([apiState, selectedPolkadotAccountsState, nativeTokenDecimalState, nativeTokenPriceState('usd')])
+    waitForAll([apiState, selectedSubstrateAccountsState, nativeTokenDecimalState, nativeTokenPriceState('usd')])
   )
 
   const stakingsLoadable = useChainState('derive', 'staking', 'accounts', [

--- a/apps/web/src/archetypes/Wallet/Crowdloans.tsx
+++ b/apps/web/src/archetypes/Wallet/Crowdloans.tsx
@@ -1,5 +1,5 @@
 import { ChainLogo, ExtensionStatusGate, Info, Panel, PanelSection, Pendor } from '@components'
-import { selectedPolkadotAccountsState } from '@domains/accounts/recoils'
+import { selectedSubstrateAccountsState } from '@domains/accounts/recoils'
 import { useTotalCrowdloanTotalFiatAmount } from '@domains/crowdloans/hooks'
 import styled from '@emotion/styled'
 import { CrowdloanContribution, useCrowdloanContributions } from '@libs/crowdloans'
@@ -145,7 +145,7 @@ const ExtensionUnavailable = styled((props: any) => {
 
 const Crowdloans = ({ className }: { className?: string }) => {
   const { t } = useTranslation()
-  const accounts = useRecoilValue(selectedPolkadotAccountsState).map(x => x.address)
+  const accounts = useRecoilValue(selectedSubstrateAccountsState).map(x => x.address)
   const { contributions, hydrated: contributionsHydrated } = useCrowdloanContributions({ accounts })
   const crowdloansUsd = useTotalCrowdloanTotalFiatAmount()
 

--- a/apps/web/src/domains/accounts/recoils.ts
+++ b/apps/web/src/domains/accounts/recoils.ts
@@ -7,8 +7,8 @@ export const accountsState = atom<Array<{ address: string; name?: string }>>({
   default: [],
 })
 
-export const polkadotAccountsState = selector({
-  key: 'PolkadotAccounts',
+export const substrateAccountsState = selector({
+  key: 'SubstrateAccounts',
   get: ({ get }) => {
     const accounts = get(accountsState)
     return accounts.filter((x: any) => x['type'] !== 'ethereum')
@@ -31,8 +31,8 @@ export const selectedAccountsState = selector({
   },
 })
 
-export const selectedPolkadotAccountsState = selector({
-  key: 'SelectedPolkadotAccounts',
+export const selectedSubstrateAccountsState = selector({
+  key: 'SelectedSubstrateAccounts',
   get: ({ get }) => {
     return get(selectedAccountsState).filter((x: any) => x['type'] !== 'ethereum')
   },

--- a/apps/web/src/domains/crowdloans/hooks.ts
+++ b/apps/web/src/domains/crowdloans/hooks.ts
@@ -1,4 +1,4 @@
-import { selectedPolkadotAccountsState } from '@domains/accounts/recoils'
+import { selectedSubstrateAccountsState } from '@domains/accounts/recoils'
 import { usePortfolio } from '@libs/portfolio'
 import { encodeAnyAddress } from '@talismn/util'
 import BigNumber from 'bignumber.js'
@@ -6,7 +6,7 @@ import { useMemo } from 'react'
 import { useRecoilValue } from 'recoil'
 
 export const useTotalCrowdloanTotalFiatAmount = () => {
-  const accounts = useRecoilValue(selectedPolkadotAccountsState).map(x => x.address)
+  const accounts = useRecoilValue(selectedSubstrateAccountsState).map(x => x.address)
   const { totalCrowdloansUsdByAddress } = usePortfolio()
   const genericAccounts = useMemo(() => accounts?.map(account => encodeAnyAddress(account, 42)), [accounts])
   return useMemo(

--- a/apps/web/src/domains/fastUnstake/hooks.ts
+++ b/apps/web/src/domains/fastUnstake/hooks.ts
@@ -1,4 +1,4 @@
-import { polkadotAccountsState } from '@domains/accounts/recoils'
+import { substrateAccountsState } from '@domains/accounts/recoils'
 import { apiState, chainRpcState } from '@domains/chains/recoils'
 import { useChainState } from '@domains/common/hooks'
 import { ApiPromise, WsProvider } from '@polkadot/api'
@@ -61,7 +61,7 @@ export const useExposedAccounts = () => {
 }
 
 export const useFastUnstakeEligibleAccounts = () => {
-  const accounts = useRecoilValue(polkadotAccountsState)
+  const accounts = useRecoilValue(substrateAccountsState)
 
   const exposedAccountsLoadable = useExposedAccounts()
   const ledgersLoadable = useChainState(

--- a/apps/web/src/domains/nominationPools/hooks/usePoolUnlocking.ts
+++ b/apps/web/src/domains/nominationPools/hooks/usePoolUnlocking.ts
@@ -1,4 +1,4 @@
-import { selectedPolkadotAccountsState } from '@domains/accounts/recoils'
+import { selectedSubstrateAccountsState } from '@domains/accounts/recoils'
 import { useChainState } from '@domains/common/hooks'
 import BN from 'bn.js'
 import { useMemo } from 'react'
@@ -7,7 +7,7 @@ import { useRecoilValue, waitForAll } from 'recoil'
 export const usePoolUnlocking = () => {
   const sessionProgressLoadable = useChainState('derive', 'session', 'progress', [])
 
-  const [accounts] = useRecoilValue(waitForAll([selectedPolkadotAccountsState]))
+  const [accounts] = useRecoilValue(waitForAll([selectedSubstrateAccountsState]))
 
   const poolMembersLoadable = useChainState(
     'query',

--- a/apps/web/src/domains/nominationPools/recoils.ts
+++ b/apps/web/src/domains/nominationPools/recoils.ts
@@ -1,4 +1,4 @@
-import { polkadotAccountsState } from '@domains/accounts/recoils'
+import { substrateAccountsState } from '@domains/accounts/recoils'
 import { chainReadIdState } from '@domains/common/recoils'
 import type { AnyNumber } from '@polkadot/types-codec/types'
 import DotPoolSelector, { ValidatorSelector, defaultOptions } from '@talismn/dot-pool-selector'
@@ -12,7 +12,7 @@ export const allPendingPoolRewardsState = selector({
     get(chainReadIdState)
 
     const api = get(apiState)
-    const accounts = get(polkadotAccountsState)
+    const accounts = get(substrateAccountsState)
 
     return Promise.all(
       accounts.map(({ address }) =>

--- a/apps/web/src/domains/staking/hooks/useTotalStaked.ts
+++ b/apps/web/src/domains/staking/hooks/useTotalStaked.ts
@@ -1,11 +1,11 @@
-import { polkadotAccountsState } from '@domains/accounts/recoils'
+import { substrateAccountsState } from '@domains/accounts/recoils'
 import { useChainState, useTokenAmountFromAtomics } from '@domains/common/hooks'
 import BN from 'bn.js'
 import { useMemo } from 'react'
 import { useRecoilValue } from 'recoil'
 
 export const useTotalStaked = () => {
-  const accounts = useRecoilValue(polkadotAccountsState)
+  const accounts = useRecoilValue(substrateAccountsState)
   const poolMembersLoadable = useChainState(
     'query',
     'nominationPools',

--- a/apps/web/src/libs/crowdloans/useCrowdloanContributions.tsx
+++ b/apps/web/src/libs/crowdloans/useCrowdloanContributions.tsx
@@ -1,4 +1,4 @@
-import { polkadotAccountsState } from '@domains/accounts/recoils'
+import { substrateAccountsState } from '@domains/accounts/recoils'
 import { chainApiState } from '@domains/chains/recoils'
 import { SupportedRelaychains } from '@libs/talisman/util/_config'
 import { u8aToHex } from '@polkadot/util'
@@ -30,7 +30,7 @@ export function useCrowdloanContributions({
   // TODO: clean me or kill me
   const apiLoadable = useRecoilValueLoadable(waitForAll([chainApiState('polkadot'), chainApiState('kusama')]))
 
-  const allAccounts = useRecoilValue(polkadotAccountsState)
+  const allAccounts = useRecoilValue(substrateAccountsState)
   const [contributions, setContributions] = useState<CrowdloanContribution[]>([])
   const [hydrated, setHydrated] = useState(false)
 

--- a/apps/web/src/routes/Staking.tsx
+++ b/apps/web/src/routes/Staking.tsx
@@ -8,7 +8,7 @@ import PoolExitingInProgress from '@components/recipes/PoolExitingInProgress'
 import PoolSelectorDialog from '@components/recipes/PoolSelectorDialog'
 import { PoolStatus } from '@components/recipes/PoolStatusIndicator'
 import StakingInput from '@components/recipes/StakingInput'
-import { polkadotAccountsState } from '@domains/accounts/recoils'
+import { substrateAccountsState } from '@domains/accounts/recoils'
 import { apiState, chainState, nativeTokenDecimalState } from '@domains/chains/recoils'
 import { useTokenAmountFromAtomics } from '@domains/common/hooks'
 import useChainState from '@domains/common/hooks/useChainState'
@@ -38,7 +38,7 @@ const availableToStakeState = selector({
     get(chainReadIdState)
 
     const api = get(apiState)
-    const accounts = get(polkadotAccountsState)
+    const accounts = get(substrateAccountsState)
 
     const balances = await Promise.all(accounts.map(({ address }) => api.derive.balances.all(address)))
 
@@ -51,7 +51,7 @@ const availableToStakeState = selector({
 })
 
 const Statistics = () => {
-  const accounts = useRecoilValue(polkadotAccountsState)
+  const accounts = useRecoilValue(substrateAccountsState)
   const poolMembersLoadable = useChainState(
     'query',
     'nominationPools',
@@ -271,7 +271,7 @@ const selectedAccountState = atom({
   key: 'Page/Staking/SelectedAccount',
   default: selector({
     key: 'Page/Staking/SelectedAccount/Default',
-    get: ({ get }) => get(polkadotAccountsState)[0],
+    get: ({ get }) => get(substrateAccountsState)[0],
   }),
 })
 
@@ -291,7 +291,7 @@ const Input = () => {
   )
 
   const [api, accounts, recommendedPools, pendingRewards] = useRecoilValue(
-    waitForAll([apiState, polkadotAccountsState, recommendedPoolsState, allPendingPoolRewardsState])
+    waitForAll([apiState, substrateAccountsState, recommendedPoolsState, allPendingPoolRewardsState])
   )
 
   const initialPoolId = poolIdFromSearch ?? recommendedPools[0]?.poolId


### PR DESCRIPTION
This is the correct term for substrate compatible accounts