### PR TITLE
fix: fixed logos for assets in breakdown and undefined

### DIFF
--- a/apps/web/src/components/recipes/Asset/Asset.tsx
+++ b/apps/web/src/components/recipes/Asset/Asset.tsx
@@ -243,9 +243,9 @@ const Asset = Object.assign((props: AssetProps) => {
                 <div css={{ width: '1em', height: '1em' }}>
                   <img
                     src={
-                      `https://raw.githubusercontent.com/TalismanSociety/chaindata/v3/assets/chains/${
-                        token?.tokenDetails?.chain?.id ?? token?.tokenDetails?.evmNetwork?.id
-                      }.svg` ?? token?.tokenDetails?.logo
+                      token?.tokenDetails?.evmNetwork
+                        ? token?.tokenDetails?.logo
+                        : `https://raw.githubusercontent.com/TalismanSociety/chaindata/v3/assets/chains/${token?.tokenDetails?.chain?.id}.svg`
                     }
                     css={{ width: '100%', height: '100%', borderRadius: '50%' }}
                     alt={token?.tokenDetails?.name + ' logo'}

--- a/apps/web/src/components/recipes/AssetBreakdown/AssetBreakdownRow.tsx
+++ b/apps/web/src/components/recipes/AssetBreakdown/AssetBreakdownRow.tsx
@@ -19,6 +19,8 @@ const slideDown = keyframes`
 `
 
 export const AssetBreakdownRowHeader = ({ token, isOrml }: { token: any; isOrml?: boolean }) => {
+  console.log(token)
+
   return (
     <AssetRow>
       <div
@@ -35,7 +37,11 @@ export const AssetBreakdownRowHeader = ({ token, isOrml }: { token: any; isOrml?
           }}
         >
           <img
-            src={token?.tokenDetails?.logo}
+            src={
+              token?.tokenDetails?.evmNetwork
+                ? token?.tokenDetails?.logo
+                : `https://raw.githubusercontent.com/TalismanSociety/chaindata/v3/assets/chains/${token?.tokenDetails?.chain?.id}.svg`
+            }
             alt={token?.name}
             css={{
               width: '2em',

--- a/apps/web/src/components/recipes/AssetBreakdown/AssetBreakdownRow.tsx
+++ b/apps/web/src/components/recipes/AssetBreakdown/AssetBreakdownRow.tsx
@@ -19,8 +19,6 @@ const slideDown = keyframes`
 `
 
 export const AssetBreakdownRowHeader = ({ token, isOrml }: { token: any; isOrml?: boolean }) => {
-  console.log(token)
-
   return (
     <AssetRow>
       <div

--- a/apps/web/src/routes/AssetItem.tsx
+++ b/apps/web/src/routes/AssetItem.tsx
@@ -97,7 +97,7 @@ const AssetItem = () => {
                         height: '2em',
                       }}
                       alt={token?.tokenDetails?.chain?.id ?? token?.tokenDetails?.coingeckoId + ' logo'}
-                      title={token?.tokenDetails?.chain?.id ?? token?.tokenDetails?.coingeckoId}
+                      title={startCase(token?.tokenDetails?.chain?.id ?? token?.tokenDetails?.coingeckoId)}
                     />
                     <Text.Body
                       css={{


### PR DESCRIPTION
Some asset logos were undefined and asset breakdown didn't show proper logos. Temporary fix for evm is the eth token from coingecko, but fix for substrate related tokens is taken from the github.