### PR TITLE
fix: remove lock duration from claim rewards dialog

### DIFF
--- a/apps/web/src/archetypes/NominationPools/PoolStakeItem.tsx
+++ b/apps/web/src/archetypes/NominationPools/PoolStakeItem.tsx
@@ -2,10 +2,8 @@ import ClaimStakeDialog from '@components/recipes/ClaimStakeDialog'
 import PoolStake, { PoolStakeProps } from '@components/recipes/PoolStake/PoolStake'
 import { PoolStatus } from '@components/recipes/PoolStatusIndicator'
 import { useTokenAmountFromPlanck } from '@domains/common/hooks'
-import { useLockDuration } from '@domains/nominationPools/hooks/useLockDuration'
 import { UInt } from '@polkadot/types-codec'
 import { PalletNominationPoolsPoolMember } from '@polkadot/types/lookup'
-import { formatDistance } from 'date-fns'
 import { ReactNode, useCallback, useState } from 'react'
 import { useRecoilValue, waitForAll } from 'recoil'
 
@@ -40,7 +38,6 @@ const PoolStakeItem = ({
   const [isAddingStake, setIsAddingStake] = useState(false)
 
   const [claimDialogOpen, setClaimDialogOpen] = useState(false)
-  const lockDuration = useLockDuration()
   const claimPayoutExtrinsic = useExtrinsic('nominationPools', 'claimPayout')
   const restakeExtrinsic = useExtrinsic('nominationPools', 'bondExtra')
 
@@ -85,7 +82,6 @@ const PoolStakeItem = ({
         open={claimDialogOpen}
         amount={pendingRewards.decimalAmount?.toHuman() ?? '...'}
         fiatAmount={pendingRewards.localizedFiatAmount ?? '...'}
-        lockDuration={lockDuration === undefined ? '...' : formatDistance(0, lockDuration.toNumber())}
         onRequestDismiss={useCallback(() => setClaimDialogOpen(false), [])}
         onRequestClaim={useCallback(() => {
           claimPayoutExtrinsic.signAndSend(item.account?.address ?? '')

--- a/apps/web/src/components/recipes/ClaimStakeDialog/ClaimStakeDialog.stories.tsx
+++ b/apps/web/src/components/recipes/ClaimStakeDialog/ClaimStakeDialog.stories.tsx
@@ -16,5 +16,4 @@ Default.args = {
   open: true,
   amount: '120 DOT',
   fiatAmount: '$420.00',
-  lockDuration: '18 days',
 }

--- a/apps/web/src/components/recipes/ClaimStakeDialog/ClaimStakeDialog.tsx
+++ b/apps/web/src/components/recipes/ClaimStakeDialog/ClaimStakeDialog.tsx
@@ -6,7 +6,6 @@ export type ClaimStakeDialogProps = {
   open?: boolean
   amount: string
   fiatAmount: string
-  lockDuration: string
   onRequestDismiss: () => unknown
   onRequestReStake: () => unknown
   onRequestClaim: () => unknown
@@ -28,10 +27,6 @@ const ClaimStakeDialog = (props: ClaimStakeDialogProps) => (
           <br />
           You can claim your staking rewards either by re-staking (compounding) in the same nomination pool, or by
           claiming them as a freely available balance.
-          <br />
-          <br />
-          Please note that to be claimed as an available balance incurs a{' '}
-          <Text.Body alpha="high">{props.lockDuration} unstaking period.</Text.Body>
         </Text.Body>
       </div>
     }


### PR DESCRIPTION
The Figma design is wrong, as claim rewards doesn't occur in any lock duration.