### PR TITLE
build: upgrade Typescript to v5

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -77,7 +77,7 @@
   },
   "devDependencies": {
     "@acala-network/types": "^4.1.8-2.3",
-    "@craco/craco": "^7.0.0",
+    "@craco/craco": "^7.1.0",
     "@graphql-codegen/cli": "^2.16.5",
     "@graphql-codegen/client-preset": "^1.3.0",
     "@playwright/test": "^1.31.2",
@@ -110,7 +110,7 @@
     "react-app-alias": "^2.2.2",
     "react-scripts": "5.0.1",
     "storybook-preset-craco": "artisanofcode/storybook-preset-craco",
-    "typescript": "^4.9.5"
+    "typescript": "^5.0.2"
   },
   "browserslist": {
     "production": [

--- a/apps/web/src/archetypes/Transaction/TransactionLogo.tsx
+++ b/apps/web/src/archetypes/Transaction/TransactionLogo.tsx
@@ -181,7 +181,6 @@ const TransactionIconLogo = ({ className, logo, error }: TransactionIconLogoProp
         }
       `}
     >
-      {/* @ts-expect-error */}
       <IconComponent />
     </div>
   )

--- a/apps/web/src/domains/staking/recoils.ts
+++ b/apps/web/src/domains/staking/recoils.ts
@@ -1,6 +1,7 @@
 import { selectedSubstrateAccountsState } from '@domains/accounts/recoils'
 import { chainIdState, chainsState } from '@domains/chains/recoils'
 import { selectorFamily } from 'recoil'
+// @ts-expect-error
 import { Thread, spawn } from 'threads'
 
 import { WorkerFunction } from './worker'

--- a/apps/web/src/domains/staking/worker.ts
+++ b/apps/web/src/domains/staking/worker.ts
@@ -1,4 +1,5 @@
 import { ApiPromise, WsProvider } from '@polkadot/api'
+// @ts-expect-error
 import { expose } from 'threads/worker'
 
 export type WorkerFunction = typeof getStakersReward

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -16,7 +16,7 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "turbo": "^1.8.2"
   },
   "resolutions": {
+    "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.cd77847.0",
     "json-stream-stringify": "2.0.4"
   },
   "importSort": {

--- a/packages/development/tsconfig/react-library/tsconfig.json
+++ b/packages/development/tsconfig/react-library/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/create-react-app/tsconfig.json",
   "compilerOptions": {
+    "moduleResolution": "bundler",
     "resolveJsonModule": true
   }
 }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -4,12 +4,12 @@
   "packageManager": "yarn@3.4.1",
   "main": "build/commonjs/index.js",
   "exports": {
-    "import": "./build/module/index.js",
-    "require": "./build/commonjs/index.js"
+    ".": "./build/index.js",
+    "./utils": "./build/utils.js"
   },
   "scripts": {
-    "dev": "tsc --build --watch tsconfig.build.json tsconfig.build.commonjs.json",
-    "build": "tsc --build tsconfig.build.json tsconfig.build.commonjs.json",
+    "dev": "tsc --build --watch tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "codegen": "npx @svgr/cli -- src/svgs",
     "check-types": "tsc --noEmit"
   },
@@ -18,7 +18,7 @@
     "@types/react": "^18.0.28",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "typescript": "^4.9.5"
+    "typescript": "^5.0.2"
   },
   "peerDependencies": {
     "react": "18.x"

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -1,2 +1,1 @@
 export * from './components'
-export * from './context'

--- a/packages/icons/src/utils.ts
+++ b/packages/icons/src/utils.ts
@@ -1,0 +1,1 @@
+export * from './context'

--- a/packages/icons/tsconfig.build.commonjs.json
+++ b/packages/icons/tsconfig.build.commonjs.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.build.json",
-  "compilerOptions": {
-    "module": "CommonJS",
-    "outDir": "build/commonjs"
-  }
-}

--- a/packages/icons/tsconfig.build.json
+++ b/packages/icons/tsconfig.build.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "noEmit": false,
-    "outDir": "build/module"
+    "outDir": "build"
   },
   "include": ["src"]
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,15 +4,12 @@
   "packageManager": "yarn@3.4.1",
   "main": "build/commonjs/index.js",
   "exports": {
-    ".": {
-      "import": "./build/module/index.js",
-      "require": "./build/commonjs/index.js"
-    },
+    ".": "./build/index.js",
     "./assets/css/talismn.css": "./assets/css/talismn.css"
   },
   "scripts": {
-    "dev": "tsc --build --watch tsconfig.build.json tsconfig.build.commonjs.json",
-    "build": "tsc --build tsconfig.build.json tsconfig.build.commonjs.json",
+    "dev": "tsc --build --watch tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "check-types": "tsc --noEmit",
     "storybook": "start-storybook -p 6007",
     "build-storybook": "build-storybook"
@@ -42,7 +39,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hot-toast": "^2.4.0",
-    "typescript": "^4.9.5"
+    "typescript": "^5.0.2"
   },
   "peerDependencies": {
     "@emotion/react": "11.x",

--- a/packages/ui/src/atoms/Button/Button.tsx
+++ b/packages/ui/src/atoms/Button/Button.tsx
@@ -1,5 +1,5 @@
 import { useTheme } from '@emotion/react'
-import { IconContext } from '@talismn/icons'
+import { IconContext } from '@talismn/icons/utils'
 import { ElementType, ReactNode, useMemo } from 'react'
 
 import CircularProgressIndicator from '../CircularProgressIndicator'

--- a/packages/ui/src/atoms/Chip/Chip.tsx
+++ b/packages/ui/src/atoms/Chip/Chip.tsx
@@ -1,5 +1,5 @@
 import { useTheme } from '@emotion/react'
-import { IconContext } from '@talismn/icons'
+import { IconContext } from '@talismn/icons/utils'
 import { ButtonHTMLAttributes, DetailedHTMLProps, ReactNode, useMemo } from 'react'
 
 import CircularProgressIndicator from '../CircularProgressIndicator'

--- a/packages/ui/src/atoms/Icon/Icon.stories.tsx
+++ b/packages/ui/src/atoms/Icon/Icon.stories.tsx
@@ -15,9 +15,9 @@ export const Default: Story<React.SVGProps<SVGSVGElement> & { title?: string }> 
   const theme = useTheme()
   return (
     <div css={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))', gap: '1rem' }}>
-      {Object.entries(Icon as any)
+      {Object.entries(Icon)
         .filter(([name]) => name !== 'IconContext')
-        .map(([name, Icon]: [any, any]) => (
+        .map(([name, Icon]) => (
           <figure
             css={{
               display: 'flex',

--- a/packages/ui/src/atoms/Text/Text.tsx
+++ b/packages/ui/src/atoms/Text/Text.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from '@emotion/react'
 import Color from 'colorjs.io'
-import React, { ElementType, useMemo } from 'react'
+import React, { useMemo } from 'react'
 
 export type TextAlpha = 'disabled' | 'medium' | 'high'
 

--- a/packages/ui/src/organisms/NavigationDrawer/NavigationDrawer.tsx
+++ b/packages/ui/src/organisms/NavigationDrawer/NavigationDrawer.tsx
@@ -1,5 +1,6 @@
 import { keyframes, useTheme } from '@emotion/react'
-import { IconContext, X } from '@talismn/icons'
+import { X } from '@talismn/icons'
+import { IconContext } from '@talismn/icons/utils'
 import Color from 'colorjs.io'
 import {
   AnchorHTMLAttributes,

--- a/packages/ui/tsconfig.build.commonjs.json
+++ b/packages/ui/tsconfig.build.commonjs.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.build.json",
-  "compilerOptions": {
-    "module": "CommonJS",
-    "outDir": "build/commonjs"
-  }
-}

--- a/packages/ui/tsconfig.build.json
+++ b/packages/ui/tsconfig.build.json
@@ -4,7 +4,7 @@
     "noEmit": false,
     "declaration": true,
     "jsxImportSource": "@emotion/react",
-    "outDir": "build/module"
+    "outDir": "build"
   },
   "include": ["src"],
   "exclude": ["**/*.stories.*"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2127,9 +2127,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@craco/craco@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "@craco/craco@npm:7.0.0"
+"@craco/craco@npm:^7.1.0":
+  version: 7.1.0
+  resolution: "@craco/craco@npm:7.1.0"
   dependencies:
     autoprefixer: ^10.4.12
     cosmiconfig: ^7.0.1
@@ -2142,7 +2142,7 @@ __metadata:
     react-scripts: ^5.0.0
   bin:
     craco: dist/bin/craco.js
-  checksum: d8371d5508a586ea00070d66010e632c8dab2761c2dd51163003e5b4e62e044f5931b081c3d19f02eea187fd970f9ddffeeaefcae004962e63286682e41e86b1
+  checksum: d534d1ea7814e7bd9f2e2aef17821fcdb1d9cac8308e8eb04809f8f3371180086b8f673dedce1ffbefba9ded566e91e4c9663464e488bf6291461091cbd95c4e
   languageName: node
   linkType: hard
 
@@ -8261,7 +8261,7 @@ __metadata:
     "@types/react": ^18.0.28
     react: ^18.2.0
     react-dom: ^18.2.0
-    typescript: ^4.9.5
+    typescript: ^5.0.2
   peerDependencies:
     react: 18.x
   languageName: unknown
@@ -8315,7 +8315,7 @@ __metadata:
     react: ^18.2.0
     react-dom: ^18.2.0
     react-hot-toast: ^2.4.0
-    typescript: ^4.9.5
+    typescript: ^5.0.2
   peerDependencies:
     "@emotion/react": 11.x
     "@talismn/icons": "*"
@@ -8368,7 +8368,7 @@ __metadata:
   dependencies:
     "@acala-network/types": ^4.1.8-2.3
     "@apollo/client": ^3.7.7
-    "@craco/craco": ^7.0.0
+    "@craco/craco": ^7.1.0
     "@emotion/react": ^11.10.6
     "@emotion/styled": ^11.10.6
     "@google/model-viewer": ^1.12.1
@@ -8452,7 +8452,7 @@ __metadata:
     stream-browserify: ^3.0.0
     swr: ^1.3.0
     threads: ^1.7.0
-    typescript: ^4.9.5
+    typescript: ^5.0.2
     uuid: ^9.0.0
     victory: ^36.6.8
     web-vitals: ^2.1.4
@@ -27884,13 +27884,13 @@ storybook-preset-craco@artisanofcode/storybook-preset-craco:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.9.5":
-  version: 4.9.5
-  resolution: "typescript@npm:4.9.5"
+"typescript@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "typescript@npm:5.0.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: ee000bc26848147ad423b581bd250075662a354d84f0e06eb76d3b892328d8d4440b7487b5a83e851b12b255f55d71835b008a66cbf8f255a11e4400159237db
+  checksum: bef1dcd166acfc6934b2ec4d72f93edb8961a5fab36b8dd2aaf6f4f4cd5c0210f2e0850aef4724f3b4913d5aef203a94a28ded731b370880c8bcff7e4ff91fc1
   languageName: node
   linkType: hard
 
@@ -27914,13 +27914,13 @@ storybook-preset-craco@artisanofcode/storybook-preset-craco:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.9.5#~builtin<compat/typescript>":
-  version: 4.9.5
-  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=23ec76"
+"typescript@patch:typescript@^5.0.2#~builtin<compat/typescript>":
+  version: 5.0.2
+  resolution: "typescript@patch:typescript@npm%3A5.0.2#~builtin<compat/typescript>::version=5.0.2&hash=1f5320"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: ab417a2f398380c90a6cf5a5f74badd17866adf57f1165617d6a551f059c3ba0a3e4da0d147b3ac5681db9ac76a303c5876394b13b3de75fdd5b1eaa06181c9d
+  checksum: bdbf3d0aac0d6cf010fbe0536753dc19f278eb4aba88140dcd25487dfe1c56ca8b33abc0dcd42078790a939b08ebc4046f3e9bb961d77d3d2c3cfa9829da4d53
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7245,21 +7245,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/react-docgen-typescript-plugin@npm:1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0, @storybook/react-docgen-typescript-plugin@npm:canary":
-  version: 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0
-  resolution: "@storybook/react-docgen-typescript-plugin@npm:1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0"
+"@storybook/react-docgen-typescript-plugin@npm:1.0.6--canary.9.cd77847.0":
+  version: 1.0.6--canary.9.cd77847.0
+  resolution: "@storybook/react-docgen-typescript-plugin@npm:1.0.6--canary.9.cd77847.0"
   dependencies:
     debug: ^4.1.1
     endent: ^2.0.1
     find-cache-dir: ^3.3.1
     flat-cache: ^3.0.4
     micromatch: ^4.0.2
-    react-docgen-typescript: ^2.1.1
+    react-docgen-typescript: ^2.2.2
     tslib: ^2.0.0
   peerDependencies:
-    typescript: ">= 3.x"
+    typescript: ">= 4.x"
     webpack: ">= 4"
-  checksum: 91a3015d384e93d9ffb4def904cad51218eb1a9eaf504c758083f2988a97d8bf8748bc280aa629864eb26fd9f7fc05bd087df95383d719e0c914c722016804b9
+  checksum: 8f155cc34cb7d1f124c42b125b760fb58b4ba2ed2eaf109f363411f1c3b0cc6f3cb6dc15c1fa073bd6c0ec5e98b51ab24ff92def54505043f7a2a297a33a77af
   languageName: node
   linkType: hard
 
@@ -24281,7 +24281,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-docgen-typescript@npm:^2.1.1":
+"react-docgen-typescript@npm:^2.2.2":
   version: 2.2.2
   resolution: "react-docgen-typescript@npm:2.2.2"
   peerDependencies:


### PR DESCRIPTION
- Use new `bundler` module resolution strategy
- Only build ES modules for React library
- Use named export for icons lib utils