### PR TITLE
Fix: (serif font) && (baserow crash) && (typescript sdk path)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "typescript.tsdk": "node_modules\\typescript\\lib"
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/apps/web/src/components/recipes/PortfolioAllocationGraph/PortfolioAllocationGraph.tsx
+++ b/apps/web/src/components/recipes/PortfolioAllocationGraph/PortfolioAllocationGraph.tsx
@@ -133,7 +133,7 @@ const PortfolioAllocationGraph = Object.assign(
                 flyoutWidth={100}
                 flyoutHeight={100}
                 flyoutStyle={{ fill: theme.color.foreground }}
-                style={{ fontFamily: 'Surt', fontWeight: 'bold', fill: theme.color.onForeground }}
+                style={{ fontFamily: "'Surt', sans-serif", fontWeight: 'bold', fill: theme.color.onForeground }}
               />
             }
             colorScale={props.data.map(x => x.color)}

--- a/apps/web/src/libs/@talisman-crowdloans/provider.ts
+++ b/apps/web/src/libs/@talisman-crowdloans/provider.ts
@@ -39,7 +39,9 @@ const crowdloanDataState = selector<CrowdloanDetail[]>({
         },
       })
       const data = await response.json()
-      const crowdloans = data?.results?.map((crowdloan: any) => {
+      if (!Array.isArray(data?.results)) throw new Error('Incorrectly formatted crowdloans baserow result')
+
+      const crowdloans: CrowdloanDetail[] = data.results.map((crowdloan: any) => {
         const links: { [key: string]: string } = Object.keys(crowdloan).reduce(
           (acc: Record<string, string>, key: string) => {
             if (key.startsWith('links.')) {
@@ -94,7 +96,7 @@ const crowdloanDataState = selector<CrowdloanDetail[]>({
             full: crowdloan?.['bonus.full'],
             info: crowdloan?.['bonus.info'],
           },
-        } as CrowdloanDetail
+        }
       })
 
       return crowdloans

--- a/packages/ui/src/atoms/Text/Text.tsx
+++ b/packages/ui/src/atoms/Text/Text.tsx
@@ -46,7 +46,7 @@ const BaseText = <T extends React.ElementType = 'span'>({
       {...props}
       css={{
         'color': useAlpha(color, typeof alpha === 'function' ? alpha({ hover: false }) : alpha),
-        'fontFamily': 'Surt',
+        'fontFamily': "'Surt', sans-serif",
         ':hover': {
           color: useAlpha(color, typeof alpha === 'function' ? alpha({ hover: true }) : alpha),
         },
@@ -70,7 +70,7 @@ const BaseHeaderText = <T extends React.ElementType = 'h1'>({
       {...props}
       css={{
         'color': useAlpha(color, typeof alpha === 'function' ? alpha({ hover: false }) : alpha),
-        'fontFamily': 'SurtExpanded',
+        'fontFamily': "'SurtExpanded', sans-serif",
         ':hover': {
           color: useAlpha(color, typeof alpha === 'function' ? alpha({ hover: true }) : alpha),
         },

--- a/packages/ui/src/molecules/Details/Details.tsx
+++ b/packages/ui/src/molecules/Details/Details.tsx
@@ -50,7 +50,11 @@ const Details = (props: DetailsProps) => {
           },
         }}
       >
-        <Text.Body as="span" alpha={open ? 'high' : 'medium'} css={{ fontFamily: 'Surt', marginRight: '2rem' }}>
+        <Text.Body
+          as="span"
+          alpha={open ? 'high' : 'medium'}
+          css={{ fontFamily: "'Surt', sans-serif", marginRight: '2rem' }}
+        >
           {props.summary}
         </Text.Body>
         <motion.div variants={{ true: { transform: 'rotate(90deg)' } }} animate={JSON.stringify(open)}>


### PR DESCRIPTION
Fixes:
- serif font in UI when fonts still loading
- invalid baserow key crashing the UI
- vscode broken intellisense on unix due to strange `typescript.tsdk` path
  now using the one recommended [in the vscode docs](https://code.visualstudio.com/docs/typescript/typescript-compiling#_using-the-workspace-version-of-typescript) instead