### PR TITLE
feat: ability to set crowdloan contrib through baserow. 

### DIFF
--- a/apps/web/src/libs/@talisman-crowdloans/provider.ts
+++ b/apps/web/src/libs/@talisman-crowdloans/provider.ts
@@ -4,6 +4,7 @@ import { selector } from 'recoil'
 export type CrowdloanDetail = {
   id: string
   name: string
+  allowContribute: boolean
   image?: string
   headerImage?: string
   token: string
@@ -77,6 +78,7 @@ const crowdloanDataState = selector<CrowdloanDetail[]>({
         return {
           id: crowdloan?.crowdloanId,
           name: crowdloan?.name,
+          allowContribute: crowdloan?.allowContribute,
           token: crowdloan?.token,
           slug: crowdloan?.slug,
           relayId: crowdloan?.relayId,

--- a/apps/web/src/routes/Crowdloan.Detail.tsx
+++ b/apps/web/src/routes/Crowdloan.Detail.tsx
@@ -47,9 +47,11 @@ const CrowdloanDetail = styled(({ className }: { className?: string }) => {
             </PanelSection>
             <PanelSection>
               <Crowdloan.Bonus full id={id ?? ''} prefix={<Parachain.Asset id={parachainId ?? ''} type="logo" />} />
-              <Button onClick={() => openModal(<Crowdloan.Contribute id={id} />)} disabled={uiStatus !== 'active'}>
-                {t('Contribute')}
-              </Button>
+              {parachainDetails?.allowContribute && (
+                <Button onClick={() => openModal(<Crowdloan.Contribute id={id} />)} disabled={uiStatus !== 'active'}>
+                  {t('Contribute')}
+                </Button>
+              )}
             </PanelSection>
           </Panel>
 


### PR DESCRIPTION
This allows us to set whether or not a crowdloan can be contributed to by changing the toggle on baserow. Helps prevent unnecessary contributions to self funded crowdloans.