### PR TITLE
build: fix pre-commit script

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,7 +2,5 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 yarn pretty-quick --staged
-
-yarn lint &
-yarn check-types &
-wait
+yarn lint
+yarn check-types


### PR DESCRIPTION
failure does not produce correct exit code when running in parallel