### PR TITLE
fix: floating portal

### DIFF
--- a/packages/ui/src/atoms/FloatingPortal.tsx
+++ b/packages/ui/src/atoms/FloatingPortal.tsx
@@ -8,7 +8,7 @@ const FloatingPortal = (props: Exclude<Parameters<typeof BaseFloatingPortal>['0'
   useLayoutEffect(
     () =>
       setRoot(
-        Array.from(document.querySelectorAll('dialog[open]'))
+        Array.from(document.querySelectorAll('dialog'))
           .filter(x => x.contains(element))
           .at(-1) ?? document.body
       ),


### PR DESCRIPTION
should check for dialog regardless of status
because we are running a `contains` check anyway