### PR TITLE
fix: reward status when user fully unstake

### DIFF
--- a/apps/web/src/domains/nominationPools/hooks/usePoolStake.ts
+++ b/apps/web/src/domains/nominationPools/hooks/usePoolStake.ts
@@ -68,6 +68,10 @@ export const usePoolStakes = <T extends Account | Account[]>(account: T) => {
         // Calculate remaining values
         .map(({ poolMember, ...rest }, index) => {
           const status: StakeStatus = (() => {
+            if (poolMember.points.isZero()) {
+              return 'not_earning_rewards'
+            }
+
             const targets = poolNominators[index]?.unwrapOrDefault().targets
 
             if (targets?.length === 0) return 'not_nominating'


### PR DESCRIPTION
User shouldn't be able to receive any reward when their active balance is 0