### PR TITLE
chore: mark general selectors

### DIFF
--- a/apps/web/src/archetypes/Transaction/Item.tsx
+++ b/apps/web/src/archetypes/Transaction/Item.tsx
@@ -1,5 +1,5 @@
 import { Info, PanelSection } from '@components'
-import { selectedAccountsState } from '@domains/accounts/recoils'
+import { DANGEROUS_SELECTED_ACCOUNTS_STATE } from '@domains/accounts/recoils'
 import { css } from '@emotion/react'
 import styled from '@emotion/styled'
 import { ReactComponent as ExternalLink } from '@icons/external-link.svg'
@@ -24,7 +24,7 @@ type Props = {
   selectedAccount?: string
 }
 export const Item = styled(({ className, transaction, addresses, selectedAccount }: Props) => {
-  const accounts = useRecoilValue(selectedAccountsState)
+  const accounts = useRecoilValue(DANGEROUS_SELECTED_ACCOUNTS_STATE)
   const genericAddresses = useMemo(() => addresses.map(formatGenericAddress), [addresses])
 
   const { name, ss58Format, timestamp, explorerUrl, parsed, relatedAddresses, signer } = transaction

--- a/apps/web/src/archetypes/Wallet/Crowdloans.tsx
+++ b/apps/web/src/archetypes/Wallet/Crowdloans.tsx
@@ -1,7 +1,7 @@
 import { ChainLogo, ExtensionStatusGate, Info, Panel, PanelSection, Pendor } from '@components'
 import SectionHeader from '@components/molecules/SectionHeader'
 import AnimatedFiatNumber from '@components/widgets/AnimatedFiatNumber'
-import { selectedSubstrateAccountsState } from '@domains/accounts/recoils'
+import { DANGEROUS_SELECTED_SUBSTRATE_ACCOUNTS_STATE } from '@domains/accounts/recoils'
 import { tokenPriceState } from '@domains/chains/recoils'
 import { useTotalCrowdloanTotalFiatAmount } from '@domains/crowdloans/hooks'
 import styled from '@emotion/styled'
@@ -166,7 +166,7 @@ const ExtensionUnavailable = styled((props: any) => {
 
 const SuspendableCrowdloans = ({ className }: { className?: string }) => {
   const { t } = useTranslation()
-  const accounts = useRecoilValue(selectedSubstrateAccountsState)
+  const accounts = useRecoilValue(DANGEROUS_SELECTED_SUBSTRATE_ACCOUNTS_STATE)
   const { contributions, hydrated: contributionsHydrated } = useCrowdloanContributions({
     accounts: useMemo(() => accounts.map(x => x.address), [accounts]),
   })

--- a/apps/web/src/components/ExtensionStatusGate.tsx
+++ b/apps/web/src/components/ExtensionStatusGate.tsx
@@ -1,4 +1,4 @@
-import { accountsState } from '@domains/accounts/recoils'
+import { DANGEROUS_ACCOUNTS_STATE } from '@domains/accounts/recoils'
 import { allowExtensionConnectionState } from '@domains/extension/recoils'
 import { isWeb3Injected } from '@polkadot/extension-dapp'
 import { type PropsWithChildren } from 'react'
@@ -18,7 +18,7 @@ export default function ExtensionStatusGate({
   unauthorized,
   noaccount,
 }: PropsWithChildren<ExtensionStatusGateProps>): JSX.Element | null {
-  const accounts = useRecoilValue(accountsState)
+  const accounts = useRecoilValue(DANGEROUS_ACCOUNTS_STATE)
   const allowExtensionConnection = useRecoilValue(allowExtensionConnectionState)
 
   if (!isWeb3Injected && unavailable !== undefined) return unavailable

--- a/apps/web/src/components/recipes/AssetBreakdown/AssetBreakdownList.tsx
+++ b/apps/web/src/components/recipes/AssetBreakdown/AssetBreakdownList.tsx
@@ -1,4 +1,4 @@
-import { selectedAccountsState } from '@domains/accounts/recoils'
+import { DANGEROUS_SELECTED_ACCOUNTS_STATE } from '@domains/accounts/recoils'
 import styled from '@emotion/styled'
 import { BalanceFormatter, type Balances } from '@talismn/balances'
 import { formatDecimals } from '@talismn/util'
@@ -73,7 +73,7 @@ type AssetBreakdownListProps = {
 
 export const AssetBreakdownList = (props: AssetBreakdownListProps) => {
   const { token, balances } = props
-  const accounts = useRecoilValue(selectedAccountsState)
+  const accounts = useRecoilValue(DANGEROUS_SELECTED_ACCOUNTS_STATE)
 
   return (
     <Table>

--- a/apps/web/src/components/widgets/AccountsManagementMenu.tsx
+++ b/apps/web/src/components/widgets/AccountsManagementMenu.tsx
@@ -1,8 +1,8 @@
 import {
-  injectedAccountsState,
+  DANGEROUS_INJECTED_ACCOUNTS_STATE,
   readOnlyAccountsState,
   selectedAccountAddressesState,
-  selectedAccountsState,
+  DANGEROUS_SELECTED_ACCOUNTS_STATE,
 } from '@domains/accounts/recoils'
 import { fiatBalancesState, totalLocalizedFiatBalanceState } from '@domains/balances/recoils'
 import { copyAddressToClipboard } from '@domains/common/utils'
@@ -21,7 +21,7 @@ import RemoveWatchedAccountConfirmationDialog from './RemoveWatchedAccountConfir
 const AccountsManagementIconButton = (props: { size?: number | string }) => {
   const theme = useTheme()
   const allowExtensionConnection = useRecoilValue(allowExtensionConnectionState)
-  const selectedAccounts = useRecoilValue(selectedAccountsState)
+  const selectedAccounts = useRecoilValue(DANGEROUS_SELECTED_ACCOUNTS_STATE)
   const readonlyAccounts = useRecoilValue(readOnlyAccountsState)
   const isWeb3Injected = useIsWeb3Injected()
 
@@ -64,7 +64,7 @@ const AccountsManagementMenu = (props: { button: ReactNode }) => {
   const totalBalance = useRecoilValueLoadable(totalLocalizedFiatBalanceState)
 
   const setSelectedAccountAddresses = useSetRecoilState(selectedAccountAddressesState)
-  const injectedAccounts = useRecoilValue(injectedAccountsState)
+  const injectedAccounts = useRecoilValue(DANGEROUS_INJECTED_ACCOUNTS_STATE)
   const readonlyAccounts = useRecoilValue(readOnlyAccountsState)
 
   const fiatBalances = useRecoilValueLoadable(fiatBalancesState)

--- a/apps/web/src/components/widgets/staking/PoolStakes.tsx
+++ b/apps/web/src/components/widgets/staking/PoolStakes.tsx
@@ -1,10 +1,10 @@
-import { selectedSubstrateAccountsState } from '@domains/accounts'
+import { DANGEROUS_SELECTED_SUBSTRATE_ACCOUNTS_STATE } from '@domains/accounts'
 import { usePoolStakes } from '@domains/nominationPools/hooks'
 import { useRecoilValue } from 'recoil'
 import PoolStakeItem from './PoolStakeItem'
 
 const PoolStakes = () => {
-  const pools = usePoolStakes(useRecoilValue(selectedSubstrateAccountsState))
+  const pools = usePoolStakes(useRecoilValue(DANGEROUS_SELECTED_SUBSTRATE_ACCOUNTS_STATE))
 
   return (
     <>

--- a/apps/web/src/components/widgets/staking/ValidatorStakes.tsx
+++ b/apps/web/src/components/widgets/staking/ValidatorStakes.tsx
@@ -1,4 +1,4 @@
-import { selectedSubstrateAccountsState } from '@domains/accounts/recoils'
+import { DANGEROUS_SELECTED_SUBSTRATE_ACCOUNTS_STATE } from '@domains/accounts/recoils'
 import { useStakersRewardState } from '@domains/staking/recoils'
 import { useRecoilValue, useRecoilValueLoadable, waitForAll } from 'recoil'
 
@@ -6,7 +6,7 @@ import { useChainDeriveState, useChainQueryState } from '@domains/common'
 import ValidatorStakeItem from './ValidatorStakeItem'
 
 const ValidatorStakes = () => {
-  const accounts = useRecoilValue(selectedSubstrateAccountsState)
+  const accounts = useRecoilValue(DANGEROUS_SELECTED_SUBSTRATE_ACCOUNTS_STATE)
 
   const [activeEra, stakes] = useRecoilValue(
     waitForAll([

--- a/apps/web/src/domains/balances/recoils.ts
+++ b/apps/web/src/domains/balances/recoils.ts
@@ -1,6 +1,10 @@
 // TODO: nuke everything and re-write balances lib integration
 
-import { accountsState, injectedAccountsState, selectedAccountsState } from '@domains/accounts/recoils'
+import {
+  DANGEROUS_ACCOUNTS_STATE,
+  DANGEROUS_INJECTED_ACCOUNTS_STATE,
+  DANGEROUS_SELECTED_ACCOUNTS_STATE,
+} from '@domains/accounts/recoils'
 import { Balances } from '@talismn/balances'
 import { useBalances as _useBalances, useAllAddresses, useChaindata, useTokens } from '@talismn/balances-react'
 import { type ChaindataProvider, type TokenList } from '@talismn/chaindata-provider'
@@ -35,7 +39,7 @@ export const balancesState = atom<Balances>({ key: 'Balances', dangerouslyAllowM
 export const selectedBalancesState = selector({
   key: 'SelectedBalances',
   get: ({ get }) => {
-    const selectedAddresses = get(selectedAccountsState).map(x => x.address)
+    const selectedAddresses = get(DANGEROUS_SELECTED_ACCOUNTS_STATE).map(x => x.address)
     return new Balances(get(balancesState).sorted.filter(x => selectedAddresses.includes(x.address)))
   },
   dangerouslyAllowMutability: true,
@@ -48,7 +52,7 @@ export const fiatBalancesState = atom<Record<string, number>>({
 export const totalInjectedAccountsFiatBalance = selector({
   key: 'TotalInjectedAccountsFiatBalance',
   get: ({ get }) => {
-    const injecteds = get(injectedAccountsState).map(x => x.address)
+    const injecteds = get(DANGEROUS_INJECTED_ACCOUNTS_STATE).map(x => x.address)
     const fiatBalances = get(fiatBalancesState)
 
     return Object.entries(fiatBalances)
@@ -60,7 +64,7 @@ export const totalInjectedAccountsFiatBalance = selector({
 export const totalSelectedAccountsFiatBalance = selector({
   key: 'TotalSelectedAccountsFiatBalance',
   get: ({ get }) => {
-    const selecteds = get(selectedAccountsState).map(x => x.address)
+    const selecteds = get(DANGEROUS_SELECTED_ACCOUNTS_STATE).map(x => x.address)
     const fiatBalances = get(fiatBalancesState)
 
     return Object.entries(fiatBalances)
@@ -83,7 +87,7 @@ export const LegacyBalancesWatcher = () => {
   const setLegacyBalances = useSetRecoilState(legacyBalancesState)
 
   const chaindata = useChaindata()
-  const accounts = useRecoilValue(accountsState)
+  const accounts = useRecoilValue(DANGEROUS_ACCOUNTS_STATE)
   const addresses = useMemo(() => accounts.map(x => x.address), [accounts])
 
   const [, setAllAddresses] = useAllAddresses()
@@ -112,7 +116,7 @@ export const LegacyBalancesWatcher = () => {
     [balances]
   )
 
-  const selectedAccounts = useRecoilValue(selectedAccountsState)
+  const selectedAccounts = useRecoilValue(DANGEROUS_SELECTED_ACCOUNTS_STATE)
   const selectedAddresses = useMemo(() => selectedAccounts.map(x => x.address), [selectedAccounts])
 
   const balancesGroupByAddress = useMemo(() => groupBy(balances?.sorted, 'address'), [balances?.sorted])

--- a/apps/web/src/domains/crowdloans/hooks.ts
+++ b/apps/web/src/domains/crowdloans/hooks.ts
@@ -1,4 +1,4 @@
-import { selectedSubstrateAccountsState } from '@domains/accounts/recoils'
+import { DANGEROUS_SELECTED_SUBSTRATE_ACCOUNTS_STATE } from '@domains/accounts/recoils'
 import { usePortfolio } from '@libs/portfolio'
 import { encodeAnyAddress } from '@talismn/util'
 import BigNumber from 'bignumber.js'
@@ -6,7 +6,7 @@ import { useMemo } from 'react'
 import { useRecoilValue } from 'recoil'
 
 export const useTotalCrowdloanTotalFiatAmount = () => {
-  const accounts = useRecoilValue(selectedSubstrateAccountsState)
+  const accounts = useRecoilValue(DANGEROUS_SELECTED_SUBSTRATE_ACCOUNTS_STATE)
   const { totalCrowdloansUsdByAddress } = usePortfolio()
   const genericAccounts = useMemo(
     () => accounts?.map(x => x.address).map(account => encodeAnyAddress(account, 42)),

--- a/apps/web/src/domains/extension/recoils.ts
+++ b/apps/web/src/domains/extension/recoils.ts
@@ -1,4 +1,4 @@
-import { injectedAccountsState } from '@domains/accounts/recoils'
+import { DANGEROUS_INJECTED_ACCOUNTS_STATE } from '@domains/accounts/recoils'
 import { storageEffect } from '@domains/common/effects'
 import { web3AccountsSubscribe, web3Enable } from '@polkadot/extension-dapp'
 import type { InjectedWindow } from '@polkadot/extension-inject/types'
@@ -14,7 +14,7 @@ export const allowExtensionConnectionState = atom<boolean | null>({
 
 export const ExtensionWatcher = () => {
   const [allowExtensionConnection, setAllowExtensionConnection] = useRecoilState(allowExtensionConnectionState)
-  const setAccounts = useSetRecoilState(injectedAccountsState)
+  const setAccounts = useSetRecoilState(DANGEROUS_INJECTED_ACCOUNTS_STATE)
 
   useEffect(() => {
     if (!allowExtensionConnection) {

--- a/apps/web/src/domains/nominationPools/recoils.ts
+++ b/apps/web/src/domains/nominationPools/recoils.ts
@@ -1,4 +1,4 @@
-import { substrateAccountsState } from '@domains/accounts/recoils'
+import { DANGEROUS_SUBSTRATE_ACCOUNTS_STATE } from '@domains/accounts/recoils'
 import { chainsState } from '@domains/chains'
 import { SubstrateApiContext } from '@domains/common'
 import { chainReadIdState, substrateApiState } from '@domains/common/recoils'
@@ -15,7 +15,7 @@ export const allPendingPoolRewardsState = selectorFamily({
       get(chainReadIdState)
 
       const api = get(substrateApiState(endpoint))
-      const accounts = get(substrateAccountsState)
+      const accounts = get(DANGEROUS_SUBSTRATE_ACCOUNTS_STATE)
 
       return await Promise.all(
         accounts.map(

--- a/apps/web/src/domains/staking/hooks/useTotalStaked.ts
+++ b/apps/web/src/domains/staking/hooks/useTotalStaked.ts
@@ -1,4 +1,4 @@
-import { type Account, selectedSubstrateAccountsState } from '@domains/accounts/recoils'
+import { type Account, DANGEROUS_SELECTED_SUBSTRATE_ACCOUNTS_STATE } from '@domains/accounts/recoils'
 import { useNativeTokenPriceState } from '@domains/chains/recoils'
 import { useChainState, useTokenAmountFromPlanck } from '@domains/common/hooks'
 import BN from 'bn.js'
@@ -6,7 +6,7 @@ import { useMemo } from 'react'
 import { useRecoilValue } from 'recoil'
 
 export const useTotalStaked = () => {
-  const accounts: Account[] = useRecoilValue(selectedSubstrateAccountsState)
+  const accounts: Account[] = useRecoilValue(DANGEROUS_SELECTED_SUBSTRATE_ACCOUNTS_STATE)
   const poolMembersLoadable = useChainState(
     'query',
     'nominationPools',
@@ -31,7 +31,7 @@ export const useTotalStaked = () => {
 }
 
 export const useStakedBalances = () => {
-  const accounts: Account[] = useRecoilValue(selectedSubstrateAccountsState)
+  const accounts: Account[] = useRecoilValue(DANGEROUS_SELECTED_SUBSTRATE_ACCOUNTS_STATE)
   const price = useRecoilValue(useNativeTokenPriceState())
 
   const poolMembersLoadable = useChainState(

--- a/apps/web/src/domains/staking/recoils.ts
+++ b/apps/web/src/domains/staking/recoils.ts
@@ -1,4 +1,4 @@
-import { selectedSubstrateAccountsState } from '@domains/accounts/recoils'
+import { DANGEROUS_SELECTED_SUBSTRATE_ACCOUNTS_STATE } from '@domains/accounts/recoils'
 import { selectorFamily } from 'recoil'
 import { Thread, spawn } from 'threads'
 
@@ -11,7 +11,7 @@ export const stakersRewardState = selectorFamily({
   get:
     ({ endpoint, activeEra }: { endpoint: string; activeEra: number }) =>
     async ({ get }) => {
-      const addresses = get(selectedSubstrateAccountsState).map(x => x.address)
+      const addresses = get(DANGEROUS_SELECTED_SUBSTRATE_ACCOUNTS_STATE).map(x => x.address)
 
       const worker = await spawn<WorkerFunction>(new Worker(new URL('./worker', import.meta.url), { type: 'module' }))
 

--- a/apps/web/src/domains/txHistory/widgets/ExportTxHistoryWidget.tsx
+++ b/apps/web/src/domains/txHistory/widgets/ExportTxHistoryWidget.tsx
@@ -1,6 +1,6 @@
 import { type Query } from '@archetypes/Transaction/lib'
 import DialogComponent from '@components/recipes/ExportTxHistoryDialog'
-import { substrateAccountsState } from '@domains/accounts/recoils'
+import { DANGEROUS_SUBSTRATE_ACCOUNTS_STATE } from '@domains/accounts/recoils'
 import { toast } from '@talismn/ui'
 import { stringify } from 'csv-stringify/browser/esm'
 import { subMonths } from 'date-fns'
@@ -15,7 +15,7 @@ export type ExportTxHistoryWidgetProps = {
 const ExportTxHistoryWidget = (props: ExportTxHistoryWidgetProps) => {
   const [open, setOpen] = useState(false)
 
-  const accounts = useRecoilValue(substrateAccountsState)
+  const accounts = useRecoilValue(DANGEROUS_SUBSTRATE_ACCOUNTS_STATE)
   const [selectedAccount, setSelectedAccount] = useState(accounts[0])
 
   const [fromDate, setFromDate] = useState(subMonths(new Date(), 1))

--- a/apps/web/src/libs/crowdloans/useCrowdloanContributions.tsx
+++ b/apps/web/src/libs/crowdloans/useCrowdloanContributions.tsx
@@ -1,4 +1,4 @@
-import { DANGEROUS_SUBSTRATE_ACCOUNTS_STATE } from '@domains/accounts/recoils'
+import { DANGEROUS_SELECTED_SUBSTRATE_ACCOUNTS_STATE } from '@domains/accounts/recoils'
 import { chains } from '@domains/chains'
 import { substrateApiState } from '@domains/common'
 import { SupportedRelaychains } from '@libs/talisman/util/_config'
@@ -33,7 +33,7 @@ export function useCrowdloanContributions({
     waitForAll([substrateApiState(chains[0].rpc), substrateApiState(chains[1].rpc)])
   )
 
-  const allAccounts = useRecoilValue(DANGEROUS_SUBSTRATE_ACCOUNTS_STATE)
+  const allAccounts = useRecoilValue(DANGEROUS_SELECTED_SUBSTRATE_ACCOUNTS_STATE)
   const [contributions, setContributions] = useState<CrowdloanContribution[]>([])
   const [hydrated, setHydrated] = useState(false)
 

--- a/apps/web/src/libs/crowdloans/useCrowdloanContributions.tsx
+++ b/apps/web/src/libs/crowdloans/useCrowdloanContributions.tsx
@@ -1,4 +1,4 @@
-import { substrateAccountsState } from '@domains/accounts/recoils'
+import { DANGEROUS_SUBSTRATE_ACCOUNTS_STATE } from '@domains/accounts/recoils'
 import { chains } from '@domains/chains'
 import { substrateApiState } from '@domains/common'
 import { SupportedRelaychains } from '@libs/talisman/util/_config'
@@ -33,7 +33,7 @@ export function useCrowdloanContributions({
     waitForAll([substrateApiState(chains[0].rpc), substrateApiState(chains[1].rpc)])
   )
 
-  const allAccounts = useRecoilValue(substrateAccountsState)
+  const allAccounts = useRecoilValue(DANGEROUS_SUBSTRATE_ACCOUNTS_STATE)
   const [contributions, setContributions] = useState<CrowdloanContribution[]>([])
   const [hydrated, setHydrated] = useState(false)
 

--- a/apps/web/src/libs/moonbeam-contributors/Modal.tsx
+++ b/apps/web/src/libs/moonbeam-contributors/Modal.tsx
@@ -1,5 +1,5 @@
 import { MaterialLoader } from '@components'
-import { accountsState } from '@domains/accounts/recoils'
+import { DANGEROUS_ACCOUNTS_STATE } from '@domains/accounts/recoils'
 import styled from '@emotion/styled'
 import { encodeAnyAddress } from '@talismn/util'
 import { useCallback, useMemo, useState } from 'react'
@@ -12,7 +12,7 @@ import { type ContributorWithName, moonbeamRelaychain, useMoonbeamContributors }
 type ModalState = { type: 'allAccounts' } | { type: 'selectedAccount'; contributor: ContributorWithName }
 
 export default function MoonbeamContributionModal() {
-  const accounts = useRecoilValue(accountsState)
+  const accounts = useRecoilValue(DANGEROUS_ACCOUNTS_STATE)
   const { contributors, loading, refetch } = useMoonbeamContributors(accounts.map(({ address }) => address))
   const contributorsWithNames: ContributorWithName[] = useMemo(
     () =>

--- a/apps/web/src/libs/moonbeam-contributors/MoonbeamPortfolioTag.tsx
+++ b/apps/web/src/libs/moonbeam-contributors/MoonbeamPortfolioTag.tsx
@@ -1,7 +1,7 @@
 import { ReactComponent as AlertCircle } from '@assets/icons/alert-circle-bg.svg'
 import { ReactComponent as LinkCircle } from '@assets/icons/link-circle-bg.svg'
 import { useModal } from '@components'
-import { accountsState } from '@domains/accounts/recoils'
+import { DANGEROUS_ACCOUNTS_STATE } from '@domains/accounts/recoils'
 import styled from '@emotion/styled'
 import { useTranslation } from 'react-i18next'
 import { useRecoilValue } from 'recoil'
@@ -12,7 +12,7 @@ import { useMoonbeamContributors } from '.'
 export const MoonbeamPortfolioTag = styled(({ className }: { className?: string }) => {
   const { t } = useTranslation('crowdloan', { keyPrefix: 'moonbeamPortflioTag' })
   const { openModal } = useModal()
-  const accounts = useRecoilValue(accountsState)
+  const accounts = useRecoilValue(DANGEROUS_ACCOUNTS_STATE)
   const { contributors, loading } = useMoonbeamContributors(accounts.map(({ address }) => address))
   const hasUnlinked = contributors.some(contributor => contributor.rewardsAddress === null)
 

--- a/apps/web/src/libs/moonbeam-contributors/index.tsx
+++ b/apps/web/src/libs/moonbeam-contributors/index.tsx
@@ -2,7 +2,7 @@
 import { ApolloClient, InMemoryCache, type NormalizedCacheObject, gql, useQuery } from '@apollo/client'
 import { BatchHttpLink } from '@apollo/client/link/batch-http'
 import { useModal } from '@components'
-import { accountsState } from '@domains/accounts/recoils'
+import { DANGEROUS_ACCOUNTS_STATE } from '@domains/accounts/recoils'
 import { deriveExplorerUrl } from '@libs/crowdloans'
 import { Moonbeam } from '@libs/crowdloans/crowdloanOverrides'
 import { SupportedRelaychains } from '@libs/talisman/util/_config'
@@ -239,7 +239,7 @@ export function Provider({ children }: PropsWithChildren) {
 
 export function PopupProvider({ children }: PropsWithChildren) {
   const { openModal } = useModal()
-  const accounts = useRecoilValue(accountsState)
+  const accounts = useRecoilValue(DANGEROUS_ACCOUNTS_STATE)
   const { contributors, loading } = useMoonbeamContributors(accounts.map(({ address }) => address))
 
   const [showPopup, setShowPopup] = useState(false)

--- a/apps/web/src/routes/Collectibles.tsx
+++ b/apps/web/src/routes/Collectibles.tsx
@@ -1,5 +1,5 @@
 import ErrorBoundary from '@components/widgets/ErrorBoundary'
-import { type Account, selectedAccountsState } from '@domains/accounts'
+import { type Account, DANGEROUS_SELECTED_ACCOUNTS_STATE } from '@domains/accounts'
 import {
   type CollectionKey,
   nftCollectionItemsState,
@@ -263,7 +263,7 @@ const Nfts = () => {
   const collectionKey = searchParams.get(COLLECTION_KEY)
 
   const [view, setView] = useState<'collections' | 'items'>('items')
-  const accounts = useRecoilValue(selectedAccountsState)
+  const accounts = useRecoilValue(DANGEROUS_SELECTED_ACCOUNTS_STATE)
 
   // When account selections change, remove detailed collection view
   // because new account selections might not have that collection

--- a/apps/web/src/routes/TransactionHistory.tsx
+++ b/apps/web/src/routes/TransactionHistory.tsx
@@ -1,5 +1,5 @@
 import { List } from '@archetypes/Transaction'
-import { selectedAccountsState } from '@domains/accounts/recoils'
+import { DANGEROUS_SELECTED_ACCOUNTS_STATE } from '@domains/accounts/recoils'
 import styled from '@emotion/styled'
 import { useMemo } from 'react'
 import { useRecoilValue } from 'recoil'
@@ -38,7 +38,7 @@ import { useRecoilValue } from 'recoil'
 // `
 
 const TransactionHistory = styled(({ className }: { className?: string }) => {
-  const addresses = useRecoilValue(selectedAccountsState)
+  const addresses = useRecoilValue(DANGEROUS_SELECTED_ACCOUNTS_STATE)
 
   return (
     <section className={className}>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -10,7 +10,7 @@ import AccountsManagementMenu from '@components/widgets/AccountsManagementMenu'
 import { RouteErrorElement } from '@components/widgets/ErrorBoundary'
 import TeleportDialog from '@components/widgets/TeleportDialog'
 import StakeDialog from '@components/widgets/staking/StakeDialog'
-import { selectedAccountsState } from '@domains/accounts/recoils'
+import { DANGEROUS_SELECTED_ACCOUNTS_STATE } from '@domains/accounts/recoils'
 import * as MoonbeamContributors from '@libs/moonbeam-contributors'
 import * as Sentry from '@sentry/react'
 import { Compass, CreditCard, Eye, MoreHorizontal, RefreshCcw, Star, TalismanHand, Zap } from '@talismn/icons'
@@ -41,7 +41,7 @@ import TransactionHistory from './TransactionHistory'
 
 const Header = () => {
   const shouldShowAccountConnectionGuard = useShouldShowAccountConnectionGuard()
-  const accounts = useRecoilValue(selectedAccountsState)
+  const accounts = useRecoilValue(DANGEROUS_SELECTED_ACCOUNTS_STATE)
 
   if (shouldShowAccountConnectionGuard) {
     return null


### PR DESCRIPTION
Clearly mark accounts selector with mix types to avoid accidentally getting EVM & readonly accounts.