### PR TITLE
[DO NOT MERGE] refactor: text component color

### DIFF
--- a/packages/ui/src/atoms/Button/Button.tsx
+++ b/packages/ui/src/atoms/Button/Button.tsx
@@ -144,9 +144,12 @@ const Button = <T extends ButtonElementType = 'button'>({
       ]}
     >
       <Text.Body
-        color={props.disabled ? variantDisabledStyle.color : variantStyle.color}
         alpha="high"
-        css={{ position: 'relative', display: 'flex' }}
+        css={{
+          position: 'relative',
+          display: 'flex',
+          color: 'inherit',
+        }}
       >
         {hasLeadingIcon && (
           <span

--- a/packages/ui/src/atoms/Chip/Chip.tsx
+++ b/packages/ui/src/atoms/Chip/Chip.tsx
@@ -35,11 +35,11 @@ const Chip = ({ size = 'md', containerColor, contentColor, leadingContent, loadi
   return (
     <Container
       as="button"
-      color={contentColor}
       {...props}
       disabled={functionallyDisabled}
       css={[
         {
+          color: contentColor,
           lineHeight: '1em',
           display: 'flex',
           alignItems: 'center',

--- a/packages/ui/src/atoms/Text/Text.tsx
+++ b/packages/ui/src/atoms/Text/Text.tsx
@@ -1,24 +1,21 @@
-import { useTheme, type Theme } from '@emotion/react'
+import { useTheme } from '@emotion/react'
 import type React from 'react'
 
 export type TextAlpha = 'disabled' | 'medium' | 'high'
 
 type PolymorphicTextProps<T extends React.ElementType> = {
   as?: T
-  color?: string | ((theme: Theme) => string)
   alpha?: TextAlpha | ((props: { hover: boolean }) => TextAlpha)
 }
 
 export type TextProps<T extends React.ElementType> = PolymorphicTextProps<T> &
   Omit<React.ComponentPropsWithoutRef<T>, keyof PolymorphicTextProps<T>>
 
-const useAlpha = (color: string | ((theme: Theme) => string), alpha: TextAlpha) => {
+const useAlpha = (alpha: TextAlpha) => {
   const theme = useTheme()
-
-  const parsedColor = typeof color === 'string' ? color : color(theme)
   const alphaValue = theme.contentAlpha[alpha ?? 'medium']
 
-  return `color-mix(in srgb, ${parsedColor}, transparent ${Math.round((1 - alphaValue) * 100)}%)`
+  return `color-mix(in srgb, currentcolor, transparent ${Math.round((1 - alphaValue) * 100)}%) !important`
 }
 
 const NoopText = <T extends React.ElementType = 'span'>({
@@ -31,51 +28,49 @@ const NoopText = <T extends React.ElementType = 'span'>({
   return <Component {...props} />
 }
 
-const BaseText = <T extends React.ElementType = 'span'>({
-  as,
-  color: _color,
-  alpha = 'medium',
-  ...props
-}: TextProps<T>) => {
+const BaseText = <T extends React.ElementType = 'span'>({ as, alpha = 'medium', ...props }: TextProps<T>) => {
   const theme = useTheme()
   const Component = as ?? 'span'
-  const color = _color ?? theme.color.onBackground
 
   return (
-    <Component
-      {...props}
-      css={{
-        'color': useAlpha(color, typeof alpha === 'function' ? alpha({ hover: false }) : alpha),
-        'fontFamily': "'Surt', sans-serif",
-        ':hover': {
-          color: useAlpha(color, typeof alpha === 'function' ? alpha({ hover: true }) : alpha),
-        },
-      }}
-    />
+    <div
+      className={props['className']}
+      css={{ display: 'contents !important', color: theme.color.onBackground, fontSize: 'revert !important' }}
+    >
+      <Component
+        {...props}
+        css={{
+          'color': useAlpha(typeof alpha === 'function' ? alpha({ hover: false }) : alpha),
+          'fontFamily': "'Surt', sans-serif",
+          ':hover': {
+            color: useAlpha(typeof alpha === 'function' ? alpha({ hover: true }) : alpha),
+          },
+        }}
+      />
+    </div>
   )
 }
 
-const BaseHeaderText = <T extends React.ElementType = 'h1'>({
-  as,
-  color: _color,
-  alpha = 'high',
-  ...props
-}: TextProps<T>) => {
+const BaseHeaderText = <T extends React.ElementType = 'h1'>({ as, alpha = 'high', ...props }: TextProps<T>) => {
   const theme = useTheme()
   const Component = as ?? 'span'
-  const color = _color ?? theme.color.onBackground
 
   return (
-    <Component
-      {...props}
-      css={{
-        'color': useAlpha(color, typeof alpha === 'function' ? alpha({ hover: false }) : alpha),
-        'fontFamily': "'SurtExpanded', sans-serif",
-        ':hover': {
-          color: useAlpha(color, typeof alpha === 'function' ? alpha({ hover: true }) : alpha),
-        },
-      }}
-    />
+    <div
+      className={props['className']}
+      css={{ display: 'contents !important', color: theme.color.onBackground, fontSize: 'revert !important' }}
+    >
+      <Component
+        {...props}
+        css={{
+          'color': useAlpha(typeof alpha === 'function' ? alpha({ hover: false }) : alpha),
+          'fontFamily': "'SurtExpanded', sans-serif",
+          ':hover': {
+            color: useAlpha(typeof alpha === 'function' ? alpha({ hover: true }) : alpha),
+          },
+        }}
+      />
+    </div>
   )
 }
 

--- a/packages/ui/src/molecules/ContainedTextInput/ContainedTextInput.tsx
+++ b/packages/ui/src/molecules/ContainedTextInput/ContainedTextInput.tsx
@@ -112,7 +112,9 @@ const ContainedTextInput = Object.assign(
     )
   },
   {
-    ErrorLabel: (props: PropsWithChildren) => <Text.BodySmall color={theme => theme.color.onError} {...props} />,
+    ErrorLabel: (props: PropsWithChildren) => (
+      <Text.BodySmall css={theme => ({ color: theme.color.onError })} {...props} />
+    ),
   }
 )
 

--- a/packages/ui/src/molecules/SegmentedButton/SegmentedButton.tsx
+++ b/packages/ui/src/molecules/SegmentedButton/SegmentedButton.tsx
@@ -17,8 +17,11 @@ const ButtonSegment = (props: ButtonSegmentProps) => (
       <Text.Body
         as={Clickable}
         {...props}
-        color={selectedValue === props.value ? theme => theme.color.onPrimary : undefined}
-        css={{ position: 'relative', padding: '1rem 1.2rem' }}
+        css={theme => ({
+          color: selectedValue === props.value ? theme.color.onPrimary : undefined,
+          position: 'relative',
+          padding: '1rem 1.2rem',
+        })}
         onClick={() => onChange(props.value)}
       >
         {selectedValue === props.value && (

--- a/packages/ui/src/molecules/Tabs/Tabs.tsx
+++ b/packages/ui/src/molecules/Tabs/Tabs.tsx
@@ -30,9 +30,8 @@ const Tab = <T extends TabElementType = 'li'>({ as = 'li' as T, ...props }: TabP
       }}
     >
       <Text.BodyLarge
-        color={props.selected ? theme.color.primary : undefined}
         alpha={props.selected ? 'high' : 'medium'}
-        css={{ fontSize: '1.8rem', margin: 0 }}
+        css={{ color: props.selected ? theme.color.primary : undefined, fontSize: '1.8rem', margin: 0 }}
       >
         {props.children}
       </Text.BodyLarge>

--- a/packages/ui/src/molecules/TextInput/TextInput.tsx
+++ b/packages/ui/src/molecules/TextInput/TextInput.tsx
@@ -96,7 +96,7 @@ const TextInput = Object.assign(
   },
   {
     ErrorLabel: (props: PropsWithChildren) => (
-      <Text.BodySmall color={theme => theme.color.onErrorContainer} {...props} />
+      <Text.BodySmall css={theme => ({ color: theme.color.onErrorContainer })} {...props} />
     ),
     LabelButton: (props: DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>) => {
       const theme = useTheme()


### PR DESCRIPTION
Use colour from CSS rather than JS props.

Requires fix from https://chromium-review.googlesource.com/c/chromium/src/+/4601325