### PR TITLE
fix: button hover text color

### DIFF
--- a/packages/ui/src/atoms/Button/Button.tsx
+++ b/packages/ui/src/atoms/Button/Button.tsx
@@ -2,8 +2,8 @@ import { useTheme } from '@emotion/react'
 import { IconContext } from '@talismn/icons/utils'
 import { useMemo, type ElementType, type PropsWithChildren, type ReactNode } from 'react'
 
+import { useSurfaceColor } from '..'
 import CircularProgressIndicator from '../CircularProgressIndicator'
-import { Text, useSurfaceColor } from '..'
 
 type ButtonElementType = Extract<React.ElementType, 'button' | 'a'> | ElementType<any>
 
@@ -143,11 +143,7 @@ const Button = <T extends ButtonElementType = 'button'>({
         hidden && { cursor: 'default', pointerEvent: 'none', opacity: 0 },
       ]}
     >
-      <Text.Body
-        color={props.disabled ? variantDisabledStyle.color : variantStyle.color}
-        alpha="high"
-        css={{ position: 'relative', display: 'flex' }}
-      >
+      <div css={{ position: 'relative', display: 'flex' }}>
         {hasLeadingIcon && (
           <span
             css={{ position: 'absolute', top: 0, bottom: 0, left: '-1.6rem', display: 'flex', alignItems: 'center' }}
@@ -186,7 +182,7 @@ const Button = <T extends ButtonElementType = 'button'>({
             </span>
           )}
         </IconContext.Provider>
-      </Text.Body>
+      </div>
     </Component>
   )
 }


### PR DESCRIPTION
Text component was overriding button text colour on hover

<img width="622" alt="image" src="https://github.com/TalismanSociety/talisman-web/assets/19813755/25ffcbc3-3390-4e67-9a50-f52c50570e8a">
