### PR TITLE
chore: revert "ci: bump cf pages action"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,10 @@ jobs:
 
       - run: ${{ inputs.buildCommand }}
 
-      - uses: cloudflare/pages-action@v1
+      # There's a bug on version 1.4.1
+      # change this back to latest version after
+      # https://github.com/cloudflare/pages-action/commit/586d3c53b9daa978dfb149a41a624f9311ebf5c9
+      - uses: cloudflare/pages-action@v1.4.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
This reverts commit 1ea4647757f75ea36163bc1336c26ec024aa7fdb.

We're still seeing incorrect branch name on Cloudflare Pages with this version