### PR TITLE
fix: use multisig id as identifier

### DIFF
--- a/apps/multisig/src/domains/metadata-service/getTxMetadata.tsx
+++ b/apps/multisig/src/domains/metadata-service/getTxMetadata.tsx
@@ -35,7 +35,7 @@ interface TxMetadataByPkResponseRaw {
 const cache = new Map<string, Promise<TxOffchainMetadata | null>>()
 
 export async function getTxMetadataByPk(
-  callHash: string,
+  multisigId: string,
   args: TxMetadataByPkArgs
 ): Promise<TxOffchainMetadata | null> {
   const variables: TxMetadataByPkVariables = {
@@ -44,10 +44,10 @@ export async function getTxMetadataByPk(
     multisig: args.multisig.toSs58(args.chain),
     chain: args.chain.squidIds.chainData,
   }
-  if (cache.has(callHash)) return cache.get(callHash)!
+  if (cache.has(multisigId)) return cache.get(multisigId)!
 
   cache.set(
-    callHash,
+    multisigId,
     new Promise(async (resolve, reject) => {
       try {
         const query = gql`
@@ -71,7 +71,7 @@ export async function getTxMetadataByPk(
           variables as Record<string, any>
         )) as TxMetadataByPkResponseRaw
         if (res.tx_metadata_by_pk === null) {
-          console.warn(`Metadata service has no value for ${callHash}`)
+          console.warn(`Metadata service has no value for ${multisigId}`)
           resolve(null)
           return
         }
@@ -98,5 +98,5 @@ export async function getTxMetadataByPk(
       }
     })
   )
-  return cache.get(callHash)!
+  return cache.get(multisigId)!
 }

--- a/apps/multisig/src/domains/metadata-service/getTxMetadata.tsx
+++ b/apps/multisig/src/domains/metadata-service/getTxMetadata.tsx
@@ -35,7 +35,7 @@ interface TxMetadataByPkResponseRaw {
 const cache = new Map<string, Promise<TxOffchainMetadata | null>>()
 
 export async function getTxMetadataByPk(
-  multisigId: string,
+  transactionID: string,
   args: TxMetadataByPkArgs
 ): Promise<TxOffchainMetadata | null> {
   const variables: TxMetadataByPkVariables = {
@@ -44,10 +44,10 @@ export async function getTxMetadataByPk(
     multisig: args.multisig.toSs58(args.chain),
     chain: args.chain.squidIds.chainData,
   }
-  if (cache.has(multisigId)) return cache.get(multisigId)!
+  if (cache.has(transactionID)) return cache.get(transactionID)!
 
   cache.set(
-    multisigId,
+    transactionID,
     new Promise(async (resolve, reject) => {
       try {
         const query = gql`
@@ -71,7 +71,7 @@ export async function getTxMetadataByPk(
           variables as Record<string, any>
         )) as TxMetadataByPkResponseRaw
         if (res.tx_metadata_by_pk === null) {
-          console.warn(`Metadata service has no value for ${multisigId}`)
+          console.warn(`Metadata service has no value for ${transactionID}`)
           resolve(null)
           return
         }
@@ -98,5 +98,5 @@ export async function getTxMetadataByPk(
       }
     })
   )
-  return cache.get(multisigId)!
+  return cache.get(transactionID)!
 }

--- a/apps/multisig/src/domains/multisig/index.ts
+++ b/apps/multisig/src/domains/multisig/index.ts
@@ -552,7 +552,7 @@ export const usePendingTransactions = () => {
               rawPending: rawPending,
               multisig: rawPending.multisig,
               approvals: rawPending.approvals,
-              transactionID,
+              id: transactionID,
             }
           } else {
             // still no calldata. return unknown transaction
@@ -563,7 +563,7 @@ export const usePendingTransactions = () => {
               rawPending: rawPending,
               multisig: rawPending.multisig,
               approvals: rawPending.approvals,
-              transactionID,
+              id: transactionID,
             }
           }
         })

--- a/apps/multisig/src/domains/multisig/index.ts
+++ b/apps/multisig/src/domains/multisig/index.ts
@@ -18,7 +18,6 @@ import BN from 'bn.js'
 import queryString from 'query-string'
 import { useCallback, useEffect, useState } from 'react'
 import { atom, selector, useRecoilState, useRecoilValue, useRecoilValueLoadable } from 'recoil'
-import truncateMiddle from 'truncate-middle'
 
 import persistAtom from '../persist'
 
@@ -162,6 +161,7 @@ export interface Transaction {
   rawPending?: RawPendingTransaction
   decoded?: TransactionDecoded
   callData?: `0x${string}`
+  multisigId?: string
 }
 
 export const toConfirmedTxUrl = (t: Transaction) =>
@@ -482,15 +482,19 @@ export const usePendingTransactions = () => {
     const transactions = (
       await Promise.all(
         allRawPending.contents.map(async rawPending => {
-          let metadata = metadataCache[rawPending.callHash]
+          const timepoint_height = rawPending.onChainMultisig.when.height.toNumber()
+          const timepoint_index = rawPending.onChainMultisig.when.index.toNumber()
+          const multisigId = `${timepoint_height}-${timepoint_index}`
+
+          let metadata = metadataCache[multisigId]
 
           if (!metadata) {
             try {
-              const metadataValues = await getTxMetadataByPk(rawPending.callHash, {
+              const metadataValues = await getTxMetadataByPk(multisigId, {
                 multisig: rawPending.multisig.multisigAddress,
                 chain: rawPending.multisig.chain,
-                timepoint_height: rawPending.onChainMultisig.when.height.toNumber(),
-                timepoint_index: rawPending.onChainMultisig.when.index.toNumber(),
+                timepoint_height,
+                timepoint_index,
               })
 
               if (metadataValues) {
@@ -501,28 +505,28 @@ export const usePendingTransactions = () => {
                 const extrinsic = decodeCallData(pjsApi, metadataValues.callData)
                 if (!extrinsic) {
                   throw new Error(
-                    `Failed to create extrinsic from callData recieved from metadata sharing service for hash ${rawPending.callHash}`
+                    `Failed to create extrinsic from callData recieved from metadata sharing service for multisigId ${multisigId}`
                   )
                 }
 
                 const derivedHash = extrinsic.registry.hash(extrinsic.method.toU8a()).toHex()
                 if (derivedHash !== rawPending.callHash) {
                   throw new Error(
-                    `CallData from metadata sharing service for hash ${rawPending.callHash} does not match hash from chain. Expected ${rawPending.callHash}, got ${derivedHash}`
+                    `CallData from metadata sharing service for multisigId ${multisigId} does not match hash from chain. Expected ${rawPending.callHash}, got ${derivedHash}`
                   )
                 }
 
-                console.log(`Loaded metadata for callHash ${rawPending.callHash} from sharing service`)
+                console.log(`Loaded metadata for multisigId ${multisigId} from sharing service`)
                 metadata = [metadataValues, new Date()]
                 setMetadataCache({
                   ...metadataCache,
-                  [rawPending.callHash]: metadata,
+                  [multisigId]: metadata,
                 })
               } else {
-                console.warn(`allRawPending: Metadata service has no value for callHash ${rawPending.callHash}`)
+                console.warn(`allRawPending: Metadata service has no value for multisigId ${multisigId}`)
               }
             } catch (error) {
-              console.error(`Failed to fetch callData for callHash ${rawPending.callHash}:`, error)
+              console.error(`Failed to fetch callData for multisigId ${multisigId}:`, error)
             }
           }
 
@@ -548,16 +552,18 @@ export const usePendingTransactions = () => {
               rawPending: rawPending,
               multisig: rawPending.multisig,
               approvals: rawPending.approvals,
+              multisigId,
             }
           } else {
             // still no calldata. return unknown transaction
             return {
               date: rawPending.date,
-              description: `Transaction ${truncateMiddle(rawPending.callHash, 6, 4, '...')}`,
+              description: `Transaction ${multisigId}`,
               hash: rawPending.callHash,
               rawPending: rawPending,
               multisig: rawPending.multisig,
               approvals: rawPending.approvals,
+              multisigId,
             }
           }
         })

--- a/apps/multisig/src/domains/tx-history/index.tsx
+++ b/apps/multisig/src/domains/tx-history/index.tsx
@@ -159,13 +159,13 @@ export const useConfirmedTransactions = () => {
             const hash = decodedExt.registry.hash(decodedExt.method.toU8a()).toHex()
             const timepoint_height = parseInt(timepoint.height.replace(/,/g, ''))
             const timepoint_index = parseInt(timepoint.index)
-            const multisigId = `${timepoint_height}-${timepoint_index}`
+            const transactionID = `${timepoint_height}-${timepoint_index}`
 
             // try to get metadata
-            let metadata = metadataCache[multisigId]
+            let metadata = metadataCache[transactionID]
             if (!metadata) {
               try {
-                const metadataValues = await getTxMetadataByPk(multisigId, {
+                const metadataValues = await getTxMetadataByPk(transactionID, {
                   multisig: curMultisig.multisigAddress,
                   chain: curMultisig.chain,
                   timepoint_height,
@@ -176,7 +176,7 @@ export const useConfirmedTransactions = () => {
                   const extrinsicDerivedFromMetadataService = decodeCallData(api, metadataValues.callData)
                   if (!extrinsicDerivedFromMetadataService) {
                     throw new Error(
-                      `Failed to create extrinsic from callData recieved from metadata sharing service for multisigId ${multisigId}`
+                      `Failed to create extrinsic from callData recieved from metadata sharing service for transactionID ${transactionID}`
                     )
                   }
                   const derivedHash = extrinsicDerivedFromMetadataService.registry
@@ -184,18 +184,18 @@ export const useConfirmedTransactions = () => {
                     .toHex()
                   if (derivedHash !== hash) {
                     throw new Error(
-                      `CallData from metadata sharing service for multisigId ${multisigId} does not match hash from chain. Expected ${hash}, got ${derivedHash}`
+                      `CallData from metadata sharing service for transactionID ${transactionID} does not match hash from chain. Expected ${hash}, got ${derivedHash}`
                     )
                   }
-                  console.log(`Loaded metadata for multisigId ${multisigId} from sharing service`)
+                  console.log(`Loaded metadata for transactionID ${transactionID} from sharing service`)
                   metadata = [metadataValues, new Date()]
                   setMetadataCache({
                     ...metadataCache,
-                    [multisigId]: metadata,
+                    [transactionID]: metadata,
                   })
                 }
               } catch (error) {
-                console.error(`Failed to fetch callData for multisigId ${multisigId}:`, error)
+                console.error(`Failed to fetch callData for transactionID ${transactionID}:`, error)
               }
             }
 

--- a/apps/multisig/src/domains/tx-history/index.tsx
+++ b/apps/multisig/src/domains/tx-history/index.tsx
@@ -157,23 +157,26 @@ export const useConfirmedTransactions = () => {
             if (extrinsicToDecoded(curMultisig, decodedExt, curChainTokens, null) === 'not_ours') return null
 
             const hash = decodedExt.registry.hash(decodedExt.method.toU8a()).toHex()
+            const timepoint_height = parseInt(timepoint.height.replace(/,/g, ''))
+            const timepoint_index = parseInt(timepoint.index)
+            const multisigId = `${timepoint_height}-${timepoint_index}`
 
             // try to get metadata
-            let metadata = metadataCache[hash]
+            let metadata = metadataCache[multisigId]
             if (!metadata) {
               try {
-                const metadataValues = await getTxMetadataByPk(hash, {
+                const metadataValues = await getTxMetadataByPk(multisigId, {
                   multisig: curMultisig.multisigAddress,
                   chain: curMultisig.chain,
-                  timepoint_height: parseInt(timepoint.height.replace(/,/g, '')),
-                  timepoint_index: parseInt(timepoint.index),
+                  timepoint_height,
+                  timepoint_index,
                 })
 
                 if (metadataValues) {
                   const extrinsicDerivedFromMetadataService = decodeCallData(api, metadataValues.callData)
                   if (!extrinsicDerivedFromMetadataService) {
                     throw new Error(
-                      `Failed to create extrinsic from callData recieved from metadata sharing service for hash ${hash}`
+                      `Failed to create extrinsic from callData recieved from metadata sharing service for multisigId ${multisigId}`
                     )
                   }
                   const derivedHash = extrinsicDerivedFromMetadataService.registry
@@ -181,18 +184,18 @@ export const useConfirmedTransactions = () => {
                     .toHex()
                   if (derivedHash !== hash) {
                     throw new Error(
-                      `CallData from metadata sharing service for hash ${hash} does not match hash from chain. Expected ${hash}, got ${derivedHash}`
+                      `CallData from metadata sharing service for multisigId ${multisigId} does not match hash from chain. Expected ${hash}, got ${derivedHash}`
                     )
                   }
-                  console.log(`Loaded metadata for callHash ${hash} from sharing service`)
+                  console.log(`Loaded metadata for multisigId ${multisigId} from sharing service`)
                   metadata = [metadataValues, new Date()]
                   setMetadataCache({
                     ...metadataCache,
-                    [hash]: metadata,
+                    [multisigId]: metadata,
                   })
                 }
               } catch (error) {
-                console.error(`Failed to fetch callData for callHash ${hash}:`, error)
+                console.error(`Failed to fetch callData for multisigId ${multisigId}:`, error)
               }
             }
 

--- a/apps/multisig/src/domains/tx-history/index.tsx
+++ b/apps/multisig/src/domains/tx-history/index.tsx
@@ -225,6 +225,7 @@ export const useConfirmedTransactions = () => {
               callData,
               description: description || decodedExt.method.meta.name.toString(),
               decoded: decodedTx,
+              id: transactionID,
             }
             return transaction
           } else {

--- a/apps/multisig/src/layouts/Overview/Transactions/index.tsx
+++ b/apps/multisig/src/layouts/Overview/Transactions/index.tsx
@@ -106,7 +106,11 @@ const TransactionsList = ({ transactions }: { transactions: Transaction[] }) => 
           <p>{day}</p>
           {transactions.map(t => {
             return (
-              <motion.div key={t.hash} whileHover={{ scale: 1.015 }} css={{ padding: '12px 16px', cursor: 'pointer' }}>
+              <motion.div
+                key={t.multisigId}
+                whileHover={{ scale: 1.015 }}
+                css={{ padding: '12px 16px', cursor: 'pointer' }}
+              >
                 <TransactionSummaryRow onClick={() => navigate(`/overview/tx/${t.hash}`)} t={t} shortDate={true} />
               </motion.div>
             )

--- a/apps/multisig/src/layouts/Overview/Transactions/index.tsx
+++ b/apps/multisig/src/layouts/Overview/Transactions/index.tsx
@@ -106,11 +106,7 @@ const TransactionsList = ({ transactions }: { transactions: Transaction[] }) => 
           <p>{day}</p>
           {transactions.map(t => {
             return (
-              <motion.div
-                key={t.multisigId}
-                whileHover={{ scale: 1.015 }}
-                css={{ padding: '12px 16px', cursor: 'pointer' }}
-              >
+              <motion.div key={t.id} whileHover={{ scale: 1.015 }} css={{ padding: '12px 16px', cursor: 'pointer' }}>
                 <TransactionSummaryRow onClick={() => navigate(`/overview/tx/${t.hash}`)} t={t} shortDate={true} />
               </motion.div>
             )


### PR DESCRIPTION
This PR updates Transactions to use their Multisig ID, which is constructed from [Timepoint](https://paritytech.github.io/substrate/master/pallet_multisig/struct.Timepoint.html), instead of call hash as unique identifier. Call hashes aren't necessarily unique because transactions that do the exact same thing will have the same hash value.

Before:
<img width="657" alt="Screenshot 2023-09-06 at 1 30 38 AM" src="https://github.com/TalismanSociety/talisman-web/assets/81092286/655b9451-8c66-4dac-9614-00664f44c43f">

After:
<img width="645" alt="Screenshot 2023-09-06 at 1 31 09 AM" src="https://github.com/TalismanSociety/talisman-web/assets/81092286/ab715e73-af58-459b-b893-2688a6c2ce2a">

