### PR TITLE
fix: only show scrollbar when need to

### DIFF
--- a/apps/multisig/src/layouts/CreateMultisig/VaultCreated.tsx
+++ b/apps/multisig/src/layouts/CreateMultisig/VaultCreated.tsx
@@ -40,7 +40,7 @@ const MagicLink = ({
         max-width: 500px;
       `}
     >
-      <p css={{ display: 'flex', flex: '1', overflow: 'scroll', whiteSpace: 'nowrap' }}>{url}</p>
+      <p css={{ display: 'flex', flex: '1', overflow: 'auto', whiteSpace: 'nowrap' }}>{url}</p>
       <IconButton
         contentColor={`rgb(${theme.primary})`}
         onClick={() => copyToClipboard(url, 'Magic link copied to clipboard ✨')}

--- a/apps/multisig/src/layouts/Overview/NewTransactionModal/MultiSendAction.tsx
+++ b/apps/multisig/src/layouts/Overview/NewTransactionModal/MultiSendAction.tsx
@@ -65,7 +65,7 @@ const DetailsForm = (props: {
           borderBottom: props.sends.length > 0 ? '1px solid var(--color-backgroundLight)' : '0',
           padding: props.sends.length > 0 ? '40px 0' : '0',
           maxHeight: '200px',
-          overflow: 'scroll',
+          overflow: 'auto',
         }}
       >
         {props.sends.map((send, index) => {


### PR DESCRIPTION
This PR addresses UI anomaly on two screens:

### Multisend
<img width="570" alt="Screenshot 2023-09-04 at 9 17 33 PM" src="https://github.com/TalismanSociety/talisman-web/assets/81092286/f9b58469-d60d-48ee-b55a-4b86bcee0bd1">
<img width="571" alt="Screenshot 2023-09-04 at 9 17 47 PM" src="https://github.com/TalismanSociety/talisman-web/assets/81092286/d9adb041-ad8e-4bf4-96bc-d572c0f307ad">

### Vault Created Vertial scroll
<img width="791" alt="Screenshot 2023-09-14 at 2 17 49 PM" src="https://github.com/TalismanSociety/talisman-web/assets/81092286/d6edaeac-0b33-4aa2-a353-a0ebbc6e15bd">
