### PR TITLE
fix(signet): transaction id and asset id

### DIFF
--- a/apps/multisig/src/domains/balances/index.ts
+++ b/apps/multisig/src/domains/balances/index.ts
@@ -46,7 +46,7 @@ export const useAugmentedBalances = () => {
         logo: b.token.logo,
         type: b.token.type,
       }
-      return [...acc, { details: token, balance: { avaliable, unavaliable }, price: b.rates?.usd || 0 }]
+      return [...acc, { details: token, balance: { avaliable, unavaliable }, price: b.rates?.usd || 0, id: b.id }]
     }, [])
   }, [balances])
 }

--- a/apps/multisig/src/domains/chains/extrinsics.ts
+++ b/apps/multisig/src/domains/chains/extrinsics.ts
@@ -14,6 +14,7 @@ import { web3FromAddress } from '@polkadot/extension-dapp'
 import type { Call, ExtrinsicPayload, Timepoint } from '@polkadot/types/interfaces'
 import { assert, compactToU8a, u8aConcat, u8aEq } from '@polkadot/util'
 import { Address } from '@util/addresses'
+import { makeTransactionID } from '@util/misc'
 import BN from 'bn.js'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useRecoilState, useRecoilValue, useRecoilValueLoadable, useSetRecoilState } from 'recoil'
@@ -435,7 +436,7 @@ export const useApproveAsMulti = (
                     // @ts-ignore
                     const timepoint_height = result.blockNumber.toNumber() as number
                     const timepoint_index = result.txIndex as number
-                    const transactionID = `${timepoint_height}-${timepoint_index}`
+                    const transactionID = makeTransactionID(multisig.chain, timepoint_height, timepoint_index)
 
                     // Disable this line to test the metadata service
                     setMetadataCache({

--- a/apps/multisig/src/domains/multisig/index.ts
+++ b/apps/multisig/src/domains/multisig/index.ts
@@ -14,6 +14,7 @@ import { accountsState } from '@domains/extension'
 import { getTxMetadataByPk } from '@domains/metadata-service'
 import { SubmittableExtrinsic } from '@polkadot/api/types'
 import { Address, toMultisigAddress } from '@util/addresses'
+import { makeTransactionID } from '@util/misc'
 import BN from 'bn.js'
 import queryString from 'query-string'
 import { useCallback, useEffect, useState } from 'react'
@@ -524,7 +525,7 @@ export const usePendingTransactions = () => {
         allRawPending.contents.map(async rawPending => {
           const timepoint_height = rawPending.onChainMultisig.when.height.toNumber()
           const timepoint_index = rawPending.onChainMultisig.when.index.toNumber()
-          const transactionID = `${timepoint_height}-${timepoint_index}`
+          const transactionID = makeTransactionID(rawPending.multisig.chain, timepoint_height, timepoint_index)
 
           let metadata = metadataCache[transactionID]
 

--- a/apps/multisig/src/domains/tx-history/index.tsx
+++ b/apps/multisig/src/domains/tx-history/index.tsx
@@ -12,6 +12,7 @@ import {
   txOffchainMetadataState,
 } from '@domains/multisig'
 import { Address } from '@util/addresses'
+import { makeTransactionID } from '@util/misc'
 import { gql } from 'graphql-request'
 import { useCallback, useEffect, useState } from 'react'
 import { atom, selector, selectorFamily, useRecoilState, useRecoilValue, useRecoilValueLoadable } from 'recoil'
@@ -159,7 +160,7 @@ export const useConfirmedTransactions = () => {
             const hash = decodedExt.registry.hash(decodedExt.method.toU8a()).toHex()
             const timepoint_height = parseInt(timepoint.height.replace(/,/g, ''))
             const timepoint_index = parseInt(timepoint.index)
-            const transactionID = `${timepoint_height}-${timepoint_index}`
+            const transactionID = makeTransactionID(curMultisig.chain, timepoint_height, timepoint_index)
 
             // try to get metadata
             let metadata = metadataCache[transactionID]

--- a/apps/multisig/src/layouts/Overview/Assets.tsx
+++ b/apps/multisig/src/layouts/Overview/Assets.tsx
@@ -8,6 +8,7 @@ import { capitalizeFirstLetter } from '@util/strings'
 import { useMemo } from 'react'
 
 export interface TokenAugmented {
+  id: string
   details: BaseToken
   balance: {
     avaliable: number
@@ -20,7 +21,6 @@ const TokenRow = ({ augmentedToken, balance }: { augmentedToken: TokenAugmented;
   const { details, price } = augmentedToken
   return (
     <div
-      key={details.id}
       className={css`
         height: 43px;
         width: 100%;
@@ -113,7 +113,7 @@ const Assets = ({ augmentedTokens }: { augmentedTokens: TokenAugmented[] }) => {
               {avaliableSorted.map(augmentedToken => {
                 return (
                   <TokenRow
-                    key={augmentedToken.details.id}
+                    key={augmentedToken.id}
                     augmentedToken={augmentedToken}
                     balance={augmentedToken.balance.avaliable}
                   />
@@ -146,7 +146,7 @@ const Assets = ({ augmentedTokens }: { augmentedTokens: TokenAugmented[] }) => {
               {unavaliableSorted.map(augmentedToken => {
                 return (
                   <TokenRow
-                    key={augmentedToken.details.id}
+                    key={augmentedToken.id}
                     augmentedToken={augmentedToken}
                     balance={augmentedToken.balance.unavaliable}
                   />

--- a/apps/multisig/src/util/misc.ts
+++ b/apps/multisig/src/util/misc.ts
@@ -1,4 +1,10 @@
+import { Chain } from '@domains/chains'
+
 export function arrayIntersection<T>(arr1: T[], arr2: T[]): T[] {
   let set = new Set(arr2)
   return arr1.filter(item => set.has(item))
+}
+
+export function makeTransactionID(chain: Chain, timepointHeight: number, timepointIndex: number): string {
+  return `${chain.squidIds.chainData}-${timepointHeight}-${timepointIndex}`
 }


### PR DESCRIPTION
This PR addresses 2 issues:
1. Transaction ID should included chain-id to avoid having transactions with same id across different chains
2. ID of each TokenRow under Assets should use a string that is a combination of token id + account address to avoid the error below where the same asset is rendered multiple times when you switch between single / multiple multisig view. The issue is because non-unique asset ID is passed to array mapping and React cant handle that properly:

<img width="405" alt="Screenshot 2023-09-14 at 2 43 02 PM" src="https://github.com/TalismanSociety/talisman-web/assets/81092286/0389474f-aed7-4085-97a5-3b3a1d7f6d56">

Fixed:
https://github.com/TalismanSociety/talisman-web/assets/81092286/4fc759c4-ab45-45db-8282-8ff3f61f838d


