### PR TITLE
refactor: consistent addresses length

### DIFF
--- a/apps/multisig/src/components/AccountSwitcher.tsx
+++ b/apps/multisig/src/components/AccountSwitcher.tsx
@@ -1,12 +1,14 @@
 import { InjectedAccount } from '@domains/extension'
 import { CircularProgressIndicator, Identicon } from '@talismn/ui'
 import { useEffect, useMemo, useRef, useState } from 'react'
-import truncateMiddle from 'truncate-middle'
 import { ChevronVertical, Search } from '@talismn/icons'
 import { useOnClickOutside } from '../domains/common/useOnClickOutside'
 import { useSignIn } from '../domains/auth'
 import { css } from '@emotion/css'
 import { device } from '../util/breakpoints'
+import { useSelectedMultisig } from '../domains/multisig'
+import { Address } from '../util/addresses'
+import { Chain } from '../domains/chains'
 
 type Props = {
   accounts: InjectedAccount[]
@@ -17,51 +19,49 @@ type Props = {
 const AccountRow = ({
   account,
   onSelect,
+  chain,
 }: {
   account: InjectedAccount
   onSelect: (account: InjectedAccount) => void
-}) => {
-  const addressString = account.address.toSs58()
-  return (
-    <div
-      onClick={() => onSelect?.(account)}
-      css={({ color }) => ({
-        'display': 'flex',
-        'alignItems': 'center',
-        'gap': 8,
-        'padding': '8px 12px',
-        'cursor': 'pointer',
-        'width': '100%',
-        'backgroundColor': color.surface,
-        ':hover': {
-          filter: 'brightness(1.2)',
-          div: { p: { color: color.offWhite } },
-        },
-      })}
-    >
-      <Identicon size={32} css={{ width: 32, height: 32 }} value={addressString} />
-      <div css={{ display: 'flex', flexDirection: 'column', gap: 2, marginTop: 4, whiteSpace: 'nowrap' }}>
-        <p
-          css={({ color }) => ({
-            maxWidth: 80,
-            color: color.offWhite,
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-          })}
-        >
-          {account.meta.name}
-        </p>{' '}
-        <p css={({ color }) => ({ color: color.lightGrey, fontSize: 12 })}>
-          {truncateMiddle(addressString, 4, 5, '...')}
-        </p>
-      </div>
+  chain?: Chain
+}) => (
+  <div
+    onClick={() => onSelect?.(account)}
+    css={({ color }) => ({
+      'display': 'flex',
+      'alignItems': 'center',
+      'gap': 8,
+      'padding': '8px 12px',
+      'cursor': 'pointer',
+      'width': '100%',
+      'backgroundColor': color.surface,
+      ':hover': {
+        filter: 'brightness(1.2)',
+        div: { p: { color: color.offWhite } },
+      },
+    })}
+  >
+    <Identicon size={32} css={{ width: 32, height: 32 }} value={account.address.toSs58(chain)} />
+    <div css={{ display: 'flex', flexDirection: 'column', gap: 2, marginTop: 4, whiteSpace: 'nowrap' }}>
+      <p
+        css={({ color }) => ({
+          maxWidth: 80,
+          color: color.offWhite,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+        })}
+      >
+        {account.meta.name}
+      </p>{' '}
+      <p css={({ color }) => ({ color: color.lightGrey, fontSize: 12 })}>{account.address.toShortSs58(chain)}</p>
     </div>
-  )
-}
+  </div>
+)
 
 const AccountSwitcher: React.FC<Props> = ({ accounts, onSelect, selectedAccount }) => {
   const [expanded, setExpanded] = useState(false)
   const { signIn } = useSignIn()
+  const [multisig] = useSelectedMultisig()
   const ref = useRef(null)
   const [query, setQuery] = useState('')
   const [accountToSignIn, setAccountToSignIn] = useState<InjectedAccount>()
@@ -73,6 +73,15 @@ const AccountSwitcher: React.FC<Props> = ({ accounts, onSelect, selectedAccount 
   const filteredAccounts = useMemo(() => {
     return accounts.filter(acc => {
       const isSelectedAccount = selectedAccount?.address.isEqual(acc.address)
+
+      let queryAddress: Address | false = false
+      try {
+        queryAddress = Address.fromSs58(query)
+      } catch (e) {}
+
+      // query by pasting address
+      if (queryAddress) return !isSelectedAccount && queryAddress.isEqual(acc.address)
+
       const isQueryMatch =
         !query || `${acc.meta.name} ${acc.address.toSs58()}`.toLowerCase().includes(query.toLowerCase())
       return !isSelectedAccount && isQueryMatch
@@ -97,6 +106,7 @@ const AccountSwitcher: React.FC<Props> = ({ accounts, onSelect, selectedAccount 
 
   if (!selectedAccount) return null
 
+  const shortSelectedAddress = selectedAccount.address.toShortSs58(multisig.chain)
   return (
     <div ref={ref} css={{ position: 'relative', width: '100%' }}>
       <div
@@ -118,7 +128,7 @@ const AccountSwitcher: React.FC<Props> = ({ accounts, onSelect, selectedAccount 
         onClick={() => setExpanded(!expanded)}
       >
         <div css={{ display: 'flex', alignItems: 'center', gap: 8, marginRight: 8 }}>
-          <Identicon size={40} value={selectedAccount.address.toSs58()} />
+          <Identicon size={40} value={selectedAccount.address.toSs58(multisig.chain)} />
           <div
             className={css`
               width: 120px;
@@ -140,12 +150,10 @@ const AccountSwitcher: React.FC<Props> = ({ accounts, onSelect, selectedAccount 
                 marginBottom: 4,
               })}
             >
-              {selectedAccount.meta.name ?? truncateMiddle(selectedAccount.address.toSs58(), 4, 6, '...')}
+              {selectedAccount.meta.name ?? shortSelectedAddress}
             </p>
             {selectedAccount.meta.name !== undefined && (
-              <p css={({ color }) => ({ color: color.lightGrey, fontSize: 12 })}>
-                {truncateMiddle(selectedAccount.address.toSs58(), 4, 6, '...')}
-              </p>
+              <p css={({ color }) => ({ color: color.lightGrey, fontSize: 12 })}>{shortSelectedAddress}</p>
             )}
           </div>
         </div>
@@ -198,9 +206,9 @@ const AccountSwitcher: React.FC<Props> = ({ accounts, onSelect, selectedAccount 
               <CircularProgressIndicator />
               <p css={({ color }) => ({ color: color.offWhite })}>Signing In</p>
             </div>
-            <Identicon size={40} value={accountToSignIn.address.toSs58()} />
+            <Identicon size={40} value={accountToSignIn.address.toSs58(multisig.chain)} />
             <p css={({ color }) => ({ color: color.offWhite, marginTop: 8 })}>{accountToSignIn.meta.name}</p>
-            <p css={{ fontSize: 12, marginTop: 4 }}>{truncateMiddle(accountToSignIn.address.toSs58(), 4, 6, '...')}</p>
+            <p css={{ fontSize: 12, marginTop: 4 }}>{accountToSignIn.address.toShortSs58(multisig.chain)}</p>
           </div>
         ) : (
           <>
@@ -225,7 +233,12 @@ const AccountSwitcher: React.FC<Props> = ({ accounts, onSelect, selectedAccount 
             <div css={{ display: 'flex', flexDirection: 'column', flex: 1, overflowY: 'auto' }}>
               {filteredAccounts.length > 0 ? (
                 filteredAccounts.map(acc => (
-                  <AccountRow key={acc.address.toSs58()} account={acc} onSelect={handleSelectAccount} />
+                  <AccountRow
+                    key={acc.address.toSs58()}
+                    account={acc}
+                    onSelect={handleSelectAccount}
+                    chain={multisig.chain}
+                  />
                 ))
               ) : (
                 <div css={{ height: '100%', display: 'flex', alignItems: 'center', width: '100%', padding: 16 }}>

--- a/apps/multisig/src/components/AddressInput/NameAndAddress.tsx
+++ b/apps/multisig/src/components/AddressInput/NameAndAddress.tsx
@@ -1,4 +1,3 @@
-import truncateMiddle from 'truncate-middle'
 import { Chain } from '@domains/chains'
 import { Address } from '@util/addresses'
 
@@ -9,12 +8,7 @@ export const NameAndAddress: React.FC<{
   nameOrAddressOnly?: boolean
   breakLine?: boolean
 }> = ({ address, name, chain, nameOrAddressOnly, breakLine }) => {
-  if (!name)
-    return (
-      <p css={({ color }) => ({ color: color.offWhite, marginTop: 6 })}>
-        {truncateMiddle(address?.toSs58(chain) ?? '', 5, 5, '...')}
-      </p>
-    )
+  if (!name) return <p css={({ color }) => ({ color: color.offWhite, marginTop: 6 })}>{address?.toShortSs58(chain)}</p>
 
   return (
     <div
@@ -39,9 +33,7 @@ export const NameAndAddress: React.FC<{
         {name}
       </p>
       {!nameOrAddressOnly && (
-        <p css={({ color }) => ({ color: color.lightGrey, fontSize: 12 })}>
-          {truncateMiddle(address.toSs58(chain), 5, 5, '...')}
-        </p>
+        <p css={({ color }) => ({ color: color.lightGrey, fontSize: 12 })}>{address.toShortSs58(chain)}</p>
       )}
     </div>
   )

--- a/apps/multisig/src/components/AddressPill/index.tsx
+++ b/apps/multisig/src/components/AddressPill/index.tsx
@@ -2,7 +2,6 @@ import { Chain } from '@domains/chains'
 import { css } from '@emotion/css'
 import { Identicon } from '@talismn/ui'
 import { Address } from '@util/addresses'
-import truncateMiddle from 'truncate-middle'
 
 const AddressPill = ({ address, chain, name }: { address: Address; chain: Chain; name?: string }) => {
   const ss52Address = address.toSs58(chain)
@@ -37,7 +36,7 @@ const AddressPill = ({ address, chain, name }: { address: Address; chain: Chain;
           textOverflow: 'ellipsis',
         })}
       >
-        {name ?? truncateMiddle(ss52Address, 5, 5, '...')}
+        {name ?? address.toShortSs58(chain)}
       </p>
     </a>
   )

--- a/apps/multisig/src/components/Member.tsx
+++ b/apps/multisig/src/components/Member.tsx
@@ -4,7 +4,7 @@ import { css } from '@emotion/css'
 import { useTheme } from '@emotion/react'
 import { ExternalLink, Trash } from '@talismn/icons'
 import { IconButton, Identicon } from '@talismn/ui'
-import truncateMiddle from 'truncate-middle'
+import { shortenAddress } from '../util/addresses'
 
 export const Member = ({ m, chain, onDelete }: { m: AugmentedAccount; onDelete?: () => void; chain: Chain }) => {
   const theme = useTheme()
@@ -28,12 +28,12 @@ export const Member = ({ m, chain, onDelete }: { m: AugmentedAccount; onDelete?:
           {m.nickname ? (
             <span css={({ color }) => ({ color: color.offWhite })}>{m.nickname}</span>
           ) : (
-            <span css={{ color: 'var(--color-offWhite)' }}>{truncateMiddle(ss58Address, 10, 10, '...')}</span>
+            <span css={{ color: 'var(--color-offWhite)' }}>{shortenAddress(ss58Address, 'long')}</span>
           )}
           &nbsp;
           {m.you && <span>(You)</span>}
         </p>
-        {m.nickname ? <span css={{ fontSize: '12px' }}>{truncateMiddle(ss58Address, 4, 5, '...')}</span> : null}
+        {m.nickname ? <span css={{ fontSize: '12px' }}>{m.address.toShortSs58(chain)}</span> : null}
       </div>
       <div css={{ display: 'flex', alignItems: 'center', marginLeft: 'auto', gap: '8px' }}>
         {onDelete && (

--- a/apps/multisig/src/components/MemberRow/index.tsx
+++ b/apps/multisig/src/components/MemberRow/index.tsx
@@ -3,10 +3,11 @@ import { AugmentedAccount } from '@domains/multisig'
 import { css } from '@emotion/css'
 import { ExternalLink, Trash } from '@talismn/icons'
 import { Identicon } from '@talismn/ui'
-import truncateMiddle from 'truncate-middle'
+import { shortenAddress } from '../../util/addresses'
 
 const MemberRow = (props: { member: AugmentedAccount; chain: Chain; onDelete?: () => void; truncate?: boolean }) => {
   const address = props.member.address.toSs58(props.chain)
+  const shortAddress = props.member.address.toShortSs58(props.chain)
   return (
     <div
       className={css`
@@ -26,12 +27,11 @@ const MemberRow = (props: { member: AugmentedAccount; chain: Chain; onDelete?: (
         <Identicon css={{ width: 24, height: 'auto' }} value={address} />
         {props.member.nickname ? (
           <p css={({ color }) => ({ color: color.offWhite })}>
-            {props.member.nickname}{' '}
-            <span css={({ color }) => ({ color: color.lightGrey })}>{truncateMiddle(address, 5, 5, '...')}</span>
+            {props.member.nickname} <span css={({ color }) => ({ color: color.lightGrey })}>{shortAddress}</span>
             {props.member.you ? <span> (You)</span> : ''}
           </p>
         ) : (
-          <p css={({ color }) => ({ color: color.offWhite })}>{truncateMiddle(address, 8, 8, '...')}</p>
+          <p css={({ color }) => ({ color: color.offWhite })}>{shortenAddress(address, 'long')}</p>
         )}
       </div>
       <div css={{ gap: 16 }}>

--- a/apps/multisig/src/components/MultisigSelect.tsx
+++ b/apps/multisig/src/components/MultisigSelect.tsx
@@ -77,9 +77,7 @@ const VaultDetails: React.FC<{ multisig: Multisig; disableCopy?: boolean }> = ({
         {truncateMiddle(multisig.name, 24, 0, '...')}
       </p>
       <div css={{ display: 'flex', gap: 4 }}>
-        <p css={{ fontSize: 12, marginTop: 2 }}>
-          {truncateMiddle(multisig.proxyAddress.toSs58(multisig.chain), 4, 4, '...')}
-        </p>
+        <p css={{ fontSize: 12, marginTop: 2 }}>{multisig.proxyAddress.toShortSs58(multisig.chain)}</p>
         {!disableCopy && (
           <Copy
             className={css`

--- a/apps/multisig/src/layouts/AddressBook/index.tsx
+++ b/apps/multisig/src/layouts/AddressBook/index.tsx
@@ -12,7 +12,6 @@ import { Copy, Database, Plus, Trash } from '@talismn/icons'
 import { Contact, useAddressBook, useDeleteContact } from '@domains/offchain-data'
 import { AddContactModal } from './AddContactModal'
 import { useState, useMemo } from 'react'
-import truncateMiddle from 'truncate-middle'
 import { copyToClipboard } from '@domains/common'
 import { useInput } from '@hooks/useInput'
 import { Multisig, useSelectedMultisig } from '@domains/multisig'
@@ -74,7 +73,7 @@ const ContactRow: React.FC<{ contact: Contact; multisig: Multisig }> = ({ contac
         <Identicon value={address} size={32} />
         <div>
           <p css={({ color }) => ({ color: color.offWhite, marginTop: 4 })}>{contact.name}</p>
-          <p css={{ fontSize: 12 }}>{truncateMiddle(address, 5, 5, '...')}</p>
+          <p css={{ fontSize: 12 }}>{contact.address.toShortSs58(multisig.chain)}</p>
         </div>
       </div>
       <div

--- a/apps/multisig/src/layouts/Auth/AccountComboBox.tsx
+++ b/apps/multisig/src/layouts/Auth/AccountComboBox.tsx
@@ -1,7 +1,6 @@
 import { InjectedAccount } from '@domains/extension'
 import { Identicon } from '@talismn/ui'
 import { useEffect, useMemo, useRef, useState } from 'react'
-import truncateMiddle from 'truncate-middle'
 import { ChevronVertical, Search } from '@talismn/icons'
 import { useOnClickOutside } from '../../domains/common/useOnClickOutside'
 
@@ -18,7 +17,7 @@ const AccountRow = ({ account }: { account: InjectedAccount }) => {
       <Identicon size={24} value={addressString} />
       <p css={({ color }) => ({ marginTop: 4, color: color.lightGrey })}>
         <span css={{ width: '100%' }}>{account.meta.name}</span>{' '}
-        <span css={({ color }) => ({ color: color.offWhite })}>({truncateMiddle(addressString, 4, 5, '...')})</span>
+        <span css={({ color }) => ({ color: color.offWhite })}>({account.address.toShortSs58()})</span>
       </p>
     </div>
   )

--- a/apps/multisig/src/layouts/Overview/NewTransactionModal/multisend/MultiLineSendInput.tsx
+++ b/apps/multisig/src/layouts/Overview/NewTransactionModal/multisend/MultiLineSendInput.tsx
@@ -4,8 +4,7 @@ import { motion } from 'framer-motion'
 import { createTheme } from '@uiw/codemirror-themes'
 import { tags } from '@lezer/highlight'
 import { css } from '@emotion/css'
-import truncateMiddle from 'truncate-middle'
-import { Address } from '@util/addresses'
+import { Address, shortenAddress } from '@util/addresses'
 import { formatUnits, parseUnits } from '@util/numbers'
 import { BaseToken, tokenPriceState } from '@domains/chains'
 import { useOnClickOutside } from '@domains/common/useOnClickOutside'
@@ -155,7 +154,7 @@ const MultiLineSendInput: React.FC<Props> = ({
         // for invalid rows, we allow empty line for grouping, otherwise we warn user of invalid row
         if (error || !data) return input === '' ? '' : `${error ?? 'Invalid Row'}: ${input}`
         const addressToFormat = token ? data.address.toSs58(token.chain) : data.addressString
-        let formattedString = truncateMiddle(addressToFormat, 6, 6, '...')
+        let formattedString = shortenAddress(addressToFormat, 'short')
 
         if (!token) return `${formattedString}, ${data.amount}`
 

--- a/apps/multisig/src/util/addresses.ts
+++ b/apps/multisig/src/util/addresses.ts
@@ -1,5 +1,6 @@
 import { Chain } from '@domains/chains'
 import { createKeyMulti, decodeAddress, encodeAddress, sortAddresses } from '@polkadot/util-crypto'
+import truncateMiddle from 'truncate-middle'
 const { hexToU8a, isHex, u8aToHex } = require('@polkadot/util')
 
 // Represent addresses as bytes except for when we need to display them to the user.
@@ -42,6 +43,10 @@ export class Address {
     return encodeAddress(this.bytes, chain?.ss58Prefix)
   }
 
+  toShortSs58(chain?: Chain): string {
+    return shortenAddress(this.toSs58(chain))
+  }
+
   toPubKey(): string {
     return u8aToHex(this.bytes)
   }
@@ -55,4 +60,9 @@ export const toMultisigAddress = (signers: Address[], threshold: number): Addres
   // Derive the multisig address
   const multiAddressBytes = createKeyMulti(sortAddresses(signers.map(s => s.bytes)), threshold)
   return new Address(multiAddressBytes)
+}
+
+export const shortenAddress = (address: string, size: 'long' | 'short' = 'short'): string => {
+  const length = size === 'long' ? 8 : 5
+  return truncateMiddle(address, length, length, '...')
 }


### PR DESCRIPTION
This PR creates a `shortenAddress` util function that consistently truncate addresses across the app. It also adds a toShortSs58 to the `Address` class for ease of use.