### PR TITLE
fix: corrupted Wagmi cache

### DIFF
--- a/apps/web/src/domains/extension/wagmi.tsx
+++ b/apps/web/src/domains/extension/wagmi.tsx
@@ -1,10 +1,9 @@
-import type { PropsWithChildren } from 'react'
-import { WagmiConfig, configureChains, createConfig, type WindowProvider } from 'wagmi'
-import { mainnet, moonbeam, moonriver } from 'wagmi/chains'
-import { publicProvider } from 'wagmi/providers/public'
 import '@wagmi/core/window'
-
+import type { PropsWithChildren } from 'react'
+import { WagmiConfig, configureChains, createConfig, createStorage, type WindowProvider } from 'wagmi'
+import { mainnet, moonbeam, moonriver } from 'wagmi/chains'
 import { InjectedConnector } from 'wagmi/connectors/injected'
+import { publicProvider } from 'wagmi/providers/public'
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -30,6 +29,7 @@ const config = createConfig({
   publicClient,
   webSocketPublicClient,
   connectors: [wagmiInjectedConnector],
+  storage: createStorage({ storage: globalThis.sessionStorage }),
 })
 
 export const WagmiProvider = (props: PropsWithChildren) => <WagmiConfig config={config}>{props.children}</WagmiConfig>

--- a/apps/web/src/domains/extension/wagmi.tsx
+++ b/apps/web/src/domains/extension/wagmi.tsx
@@ -2,7 +2,6 @@ import '@wagmi/core/window'
 import type { PropsWithChildren } from 'react'
 import { WagmiConfig, configureChains, createConfig, createStorage, type WindowProvider } from 'wagmi'
 import { mainnet, moonbeam, moonriver } from 'wagmi/chains'
-import { InjectedConnector } from 'wagmi/connectors/injected'
 import { publicProvider } from 'wagmi/providers/public'
 
 declare global {
@@ -12,23 +11,12 @@ declare global {
   }
 }
 
-const { chains, publicClient, webSocketPublicClient } = configureChains(
-  [mainnet, moonbeam, moonriver],
-  [publicProvider()]
-)
-
-export const wagmiInjectedConnector = new InjectedConnector({
-  chains,
-  options: {
-    getProvider: () => window.talismanEth,
-  },
-})
+const { publicClient, webSocketPublicClient } = configureChains([mainnet, moonbeam, moonriver], [publicProvider()])
 
 const config = createConfig({
   autoConnect: true,
   publicClient,
   webSocketPublicClient,
-  connectors: [wagmiInjectedConnector],
   storage: createStorage({ storage: globalThis.sessionStorage }),
 })
 


### PR DESCRIPTION
after a long period of usage wagmi hooks start throwing error that will only went away after deleting `wagmi.cache` from `localStorage`