### PR TITLE
style: fix media dialog media not filling the container completely

### DIFF
--- a/packages/ui/src/molecules/MediaDialog/MediaDialog.tsx
+++ b/packages/ui/src/molecules/MediaDialog/MediaDialog.tsx
@@ -146,7 +146,16 @@ const MediaDialog = Object.assign(
               <X size="2.4rem" />
             </Button>
           </div>
-          <div css={{ gridArea: 'media', aspectRatio: '1 / 1' }}>{media}</div>
+          <div
+            css={{
+              gridArea: 'media',
+              // Block display for some reason has children not stretching to the last ~3 pixels
+              display: 'flex',
+              aspectRatio: '1 / 1',
+            }}
+          >
+            {media}
+          </div>
           <div css={{ gridArea: 'content', display: 'flex', flexDirection: 'column' }}>
             <div css={{ 'padding': '2.4rem', '@media(min-width: 1024px)': { flex: '1 1 0', overflow: 'auto' } }}>
               {content}


### PR DESCRIPTION
Block display for some reason has children not stretching to the last ~3 pixels:

<img width="643" alt="image" src="https://github.com/TalismanSociety/talisman-web/assets/19813755/ec943977-37c7-4dd9-8cb1-37fbb6b13595">
