### PR TITLE
refactor: allow passing of tx builder function to `useExtrinsic` hook

### DIFF
--- a/apps/web/src/domains/common/hooks/useExtrinsicBatch.ts
+++ b/apps/web/src/domains/common/hooks/useExtrinsicBatch.ts
@@ -21,6 +21,7 @@ type ExtrinsicParametersMap = {
 }
 
 /**
+ * @deprecated use `useExtrinsic` instead
  * Mostly a copy of `useExtrinsic`
  * TODO: share code between to 2 hooks
  * @param extrinsics


### PR DESCRIPTION
# Example

```ts
const extrinsic = useExtrinsic(
  useCallback(
    (api: ApiPromise) => api.tx.utility.batchAll([api.tx.remark.store('foo'), api.tx.remark.store('bar')]),
    []
  )
)
```