### PR TITLE
feat: use selected account when re-staking

### DIFF
--- a/apps/web/src/components/widgets/staking/dappStaking/StakeSideSheet.tsx
+++ b/apps/web/src/components/widgets/staking/dappStaking/StakeSideSheet.tsx
@@ -186,8 +186,15 @@ type StakeSideSheetProps = {
 }
 
 const StakeSideSheetContent = (props: Omit<StakeSideSheetProps, 'onRequestDismiss'>) => {
+  const [searchParams] = useSearchParams()
+
   const [chain, dapps] = useRecoilValue(waitForAll([useChainState(), useRegisteredDappsState()]))
-  const [[account], accountSelector] = useAccountSelector(useRecoilValue(writeableSubstrateAccountsState), 0)
+  const [[account], accountSelector] = useAccountSelector(
+    useRecoilValue(writeableSubstrateAccountsState),
+    searchParams.get('account') === null
+      ? 0
+      : accounts => accounts?.find(x => x.address === searchParams.get('account'))
+  )
   const [dapp, setDapp] = useState(dapps.at(0))
 
   const [dappSelectorDialogOpen, setDappSelectorDialogOpen] = useState(false)
@@ -323,6 +330,7 @@ export default () => {
             sp.delete('action')
             sp.delete('type')
             sp.delete('chain')
+            sp.delete('account')
             return sp
           })
         }

--- a/apps/web/src/components/widgets/staking/dappStaking/Stakes.tsx
+++ b/apps/web/src/components/widgets/staking/dappStaking/Stakes.tsx
@@ -124,7 +124,7 @@ const Stake = ({ account }: { account: Account }) => {
               if (stake.dapps.length > 0) {
                 setAddStakeDialogOpen(true)
               } else {
-                navigate(`?action=stake&type=dapp-staking&chain=${chain.id}`)
+                navigate(`?action=stake&type=dapp-staking&chain=${chain.id}&account=${account.address}`)
               }
               setLockedDialogOpen(false)
             })


### PR DESCRIPTION
When opening stake side sheet from locked token dialog, stake side sheet should pre-populate account selection with the selected account