### PR TITLE
refactor: export theme module declaration

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -25,13 +25,15 @@ export const App = () => {
 }
 ```
 
-## Typing the theme
+## Extending the theme
 
 ```ts
 import { TalismanTheme } from '@talismn/ui'
 
 declare module '@emotion/react' {
-  export interface Theme extends TalismanTheme {}
+  export interface Theme extends TalismanTheme {
+    customProperty: 'customValue'
+  }
 }
 ```
 

--- a/packages/ui/src/global.d.ts
+++ b/packages/ui/src/global.d.ts
@@ -1,5 +1,4 @@
-import { type ModelViewerElement } from '@google/model-viewer'
-import { type TalismanTheme } from './theme'
+import type { ModelViewerElement } from '@google/model-viewer'
 
 declare global {
   namespace JSX {
@@ -8,9 +7,4 @@ declare global {
       ['model-viewer']: Partial<ModelViewerElement>
     }
   }
-}
-
-declare module '@emotion/react' {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-  export interface Theme extends TalismanTheme {}
 }

--- a/packages/ui/src/theme.tsx
+++ b/packages/ui/src/theme.tsx
@@ -55,6 +55,11 @@ export type TalismanTheme = {
   }
 }
 
+declare module '@emotion/react' {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+  export interface Theme extends TalismanTheme {}
+}
+
 const greenDark: TalismanTheme = {
   typography: {
     h1: { fontFamily: 'SurtExpanded', fontSize: 56, margin: 0 },


### PR DESCRIPTION
So that consumer of the package don't have to augment theme type manually