### PR TITLE
chore: revert "perf: fetch token rates from balances lib"

### DIFF
--- a/apps/web/src/domains/balances/core.ts
+++ b/apps/web/src/domains/balances/core.ts
@@ -7,8 +7,7 @@ import {
   writeableAccountsState,
 } from '@domains/accounts/recoils'
 import { Balances } from '@talismn/balances'
-import { useBalances as _useBalances, useAllAddresses, useTokenRates, useTokens } from '@talismn/balances-react'
-import type { TokenRates } from '@talismn/token-rates'
+import { useBalances as _useBalances, useAllAddresses, useTokens } from '@talismn/balances-react'
 import { isNil } from 'lodash'
 import { useEffect, useMemo } from 'react'
 import { atom, selector, useRecoilCallback, useRecoilValue } from 'recoil'
@@ -73,8 +72,6 @@ export const writeableBalancesState = selector({
   cachePolicy_UNSTABLE: { eviction: 'most-recent' },
 })
 
-export const tokenRatesState = atom<Record<string, TokenRates>>({ key: 'TokenRates' })
-
 export const BalancesWatcher = () => {
   const accounts = useRecoilValue(accountsState)
   const addresses = useMemo(() => accounts.map(x => x.address), [accounts])
@@ -116,27 +113,6 @@ export const BalancesWatcher = () => {
   )
 
   useBalancesReportEffect()
-
-  const tokenRates = useTokenRates()
-
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(
-    useRecoilCallback(
-      ({ set }) =>
-        () => {
-          set(
-            tokenRatesState,
-            Object.fromEntries(
-              Object.entries(tokenRates)
-                .map(([key, value]) => [tokens[key]?.coingeckoId, value] as const)
-                .filter(([key]) => key !== undefined)
-            )
-          )
-        },
-      [tokenRates, tokens]
-    ),
-    [tokenRates, tokens]
-  )
 
   return null
 }

--- a/apps/web/src/domains/chains/recoils.ts
+++ b/apps/web/src/domains/chains/recoils.ts
@@ -1,17 +1,16 @@
-import { selectedCurrencyState, tokenRatesState } from '@domains/balances'
+import { selectedCurrencyState } from '@domains/balances'
 import { substrateApiState, useSubstrateApiEndpoint } from '@domains/common'
-import { storageEffect } from '@domains/common/effects'
 import { type BN } from '@polkadot/util'
 import { type ToBn } from '@polkadot/util/types'
 import { type Chain as ChainData, type IToken } from '@talismn/chaindata-provider'
 import { Decimal } from '@talismn/math'
-import type { TokenRateCurrency } from '@talismn/token-rates'
 import { Maybe } from '@util/monads'
 import { nullToUndefined } from '@util/nullToUndefine'
 import { useContext } from 'react'
 import { atom, selector, selectorFamily, waitForAll, type RecoilValueReadOnly } from 'recoil'
 import { ChainContext } from '.'
 import { chainConfigs } from './config'
+import { storageEffect } from '@domains/common/effects'
 
 export const chainState = selectorFamily({
   key: 'Chain',
@@ -78,7 +77,28 @@ export const tokenPriceState = selectorFamily({
     ({ coingeckoId, ...params }: { coingeckoId: string; currency?: string }) =>
     async ({ get }) => {
       const currency = params.currency ?? get(selectedCurrencyState)
-      return get(tokenRatesState)[coingeckoId]?.[currency as TokenRateCurrency] ?? 0
+      try {
+        const url = new URL('/api/v3/simple/price', import.meta.env.REACT_APP_COIN_GECKO_API)
+        url.searchParams.set('ids', coingeckoId)
+        url.searchParams.set('vs_currencies', currency)
+
+        const result = await fetch(url, {
+          headers:
+            import.meta.env.REACT_APP_COIN_GECKO_API_KEY === undefined
+              ? undefined
+              : import.meta.env.REACT_APP_COIN_GECKO_API_TIER === 'pro'
+              ? { 'x-cg-pro-api-key': import.meta.env.REACT_APP_COIN_GECKO_API_KEY }
+              : import.meta.env.REACT_APP_COIN_GECKO_API_TIER === 'demo'
+              ? { 'x-cg-demo-api-key': import.meta.env.REACT_APP_COIN_GECKO_API_KEY }
+              : undefined,
+        }).then(async x => await x.json())
+
+        return result[coingeckoId][currency] as number
+      } catch {
+        // Coingecko has rate limit, better to return 0 than to crash the session
+        // TODO: find alternative or purchase Coingecko subscription
+        return 0
+      }
     },
 })
 


### PR DESCRIPTION
We no longer need to do this with the Coingecko proxy, plus performance is much better when not using balances library since multiple components won't have to re-render any more every time balances library update itself.