### PR TITLE
refactor: use custom error class instead of symbol to skip error reporting

### DIFF
--- a/apps/web/src/domains/common/consts.ts
+++ b/apps/web/src/domains/common/consts.ts
@@ -1,1 +1,0 @@
-export const skipErrorReporting = Symbol('skipErrorReporting')

--- a/apps/web/src/domains/common/errors.ts
+++ b/apps/web/src/domains/common/errors.ts
@@ -1,0 +1,12 @@
+export class HarmlessError extends Error {
+  constructor(cause: unknown) {
+    const message =
+      typeof cause === 'string'
+        ? cause
+        : typeof cause === 'object' && cause !== null && 'message' in cause && typeof cause.message === 'string'
+        ? cause.message
+        : undefined
+
+    super(message, { cause })
+  }
+}

--- a/apps/web/src/domains/common/hooks/useExtrinsic.ts
+++ b/apps/web/src/domains/common/hooks/useExtrinsic.ts
@@ -10,7 +10,7 @@ import { useContext, useMemo, useState } from 'react'
 import { useRecoilCallback, useRecoilValue } from 'recoil'
 import { substrateApiState, useSubstrateApiEndpoint } from '..'
 import { AnalyticsContext } from '../analytics'
-import { skipErrorReporting } from '../consts'
+import { HarmlessError } from '../errors'
 import { extrinsicMiddleware } from '../extrinsicMiddleware'
 import { toastExtrinsic } from '../utils'
 
@@ -186,7 +186,7 @@ export function useExtrinsic(
             // Insufficient fees
             (error instanceof RpcError && error.code === 1010)
           ) {
-            throw Object.assign(error, { [skipErrorReporting]: true })
+            throw new HarmlessError(error)
           } else {
             throw error
           }

--- a/apps/web/src/domains/common/sentry.ts
+++ b/apps/web/src/domains/common/sentry.ts
@@ -2,7 +2,7 @@ import { init, reactRouterV6Instrumentation } from '@sentry/react'
 import { BrowserTracing } from '@sentry/tracing'
 import { useEffect } from 'react'
 import { createRoutesFromChildren, matchRoutes, useLocation, useNavigationType } from 'react-router-dom'
-import { skipErrorReporting } from './consts'
+import { HarmlessError } from './errors'
 
 export const initSentry = () =>
   init({
@@ -21,12 +21,7 @@ export const initSentry = () =>
     ],
     tracesSampleRate: 0.5,
     beforeSend: (event, hint) => {
-      if (
-        hint.originalException !== undefined &&
-        hint.originalException !== null &&
-        // @ts-expect-error
-        skipErrorReporting in hint.originalException
-      ) {
+      if (hint.originalException instanceof HarmlessError) {
         return null
       }
 


### PR DESCRIPTION
Fixes #1049 