### PR TITLE
style: fix text input supporting text spacing

### DIFF
--- a/packages/ui/src/molecules/TextInput/TextInput.tsx
+++ b/packages/ui/src/molecules/TextInput/TextInput.tsx
@@ -62,7 +62,7 @@ const TextInput = Object.assign(
                 justifyContent: 'space-between',
                 alignItems: 'center',
                 marginBottom: '0.8rem',
-                'label:empty::after': {
+                '*:empty::after': {
                   content: `"\u200B"`,
                 },
               }}
@@ -120,7 +120,7 @@ const TextInput = Object.assign(
                 justifyContent: 'space-between',
                 alignItems: 'center',
                 marginTop: '0.8rem',
-                'label:empty::after': {
+                '*:empty::after': {
                   content: `"\u200B"`,
                 },
               }}


### PR DESCRIPTION
Empty character is not rendered when label or supporting text contains wrapper elements