### PR TITLE
:technologist: hide RMRK2 NFTs

### DIFF
--- a/apps/portal/src/domains/nfts/worker.ts
+++ b/apps/portal/src/domains/nfts/worker.ts
@@ -3,7 +3,6 @@ import {
   createBitCountryNftAsyncGenerator,
   createArtZeroNftAsyncGenerator,
   createEvmNftAsyncGenerator,
-  createRmrk2NftAsyncGenerator,
   createSubstrateNftKusamaAssetHubNftAsyncGenerator,
   createSubstrateNftPolkadotAssetHubNftAsyncGenerator,
   createUniqueNetworkNftAsyncGenerator,
@@ -20,7 +19,6 @@ const subscribeNfts = (address: string, options: { batchSize: number; acalaRpc: 
         : [
             createAcalaNftAsyncGenerator({ rpc: options.acalaRpc }),
             createBitCountryNftAsyncGenerator({ rpc: options.bitcountryRpc }),
-            createRmrk2NftAsyncGenerator,
             createSubstrateNftKusamaAssetHubNftAsyncGenerator,
             createSubstrateNftPolkadotAssetHubNftAsyncGenerator,
             createUniqueNetworkNftAsyncGenerator,


### PR DESCRIPTION
### Context

We would like to turn off RMRK 2 indexer for some period of time (update / maintenance)
and we would like to not to break talisman wallet ^-^ 

### Fix

remove import of `createRmrk2NftAsyncGenerator`.


