### PR TITLE
chore: add remark to Manta Staking

### DIFF
--- a/apps/portal/src/domains/staking/slpx/constants.ts
+++ b/apps/portal/src/domains/staking/slpx/constants.ts
@@ -1,4 +1,7 @@
 import { utils } from 'ethers'
 
 export const _dstGasForCall = 3000000n
-export const _adapterParams = utils.solidityPack(['uint16', 'uint256'], [1, 3200000]) as `0x${string}`
+
+const remark = import.meta.env.REACT_APP_APPLICATION_NAME ?? 'Talisman'
+
+export const _adapterParams = utils.solidityPack(['uint16', 'uint256', 'string'], [1, 3200000, remark]) as `0x${string}`


### PR DESCRIPTION
## Description

Adds a remark to Manta txns.

## Issues
[Manta contract ABI](https://github.com/bifrost-finance/slpx-contracts/blob/80f06776ee3211a64a0cccb206eb2e3508d2d1b2/deployments/manta/MantaPacificSlpx.json) does not have a `remark` arg, I am assuming it should go into the `_adapterParams`.

[`_adapterParams` is a flexible bytes array to indicate messaging adapter services](https://github.com/bifrost-finance/slpx-contracts/blob/80f06776ee3211a64a0cccb206eb2e3508d2d1b2/contracts/interfaces/IOFTV2.sol#L18) - However adding one more item to it causes `mint` fn to revert with the following reason "Relayer: wrong _adapterParameters size"