### PR TITLE
fix: default TAO apy to "--" when API fails

### DIFF
--- a/apps/portal/src/domains/staking/subtensor/atoms/taostats.ts
+++ b/apps/portal/src/domains/staking/subtensor/atoms/taostats.ts
@@ -33,6 +33,7 @@ export const taostatsAtom = atom(async () => {
     return Array.isArray(stats) ? (stats as Taostats) : []
   } catch (cause) {
     console.error('Failed to fetch TAO stats', { cause })
+    return []
   }
 })
 

--- a/apps/portal/src/domains/staking/subtensor/atoms/taostats.ts
+++ b/apps/portal/src/domains/staking/subtensor/atoms/taostats.ts
@@ -32,7 +32,7 @@ export const taostatsAtom = atom(async () => {
     const stats = await (await fetch(TAOSTATS_DATA_URL)).json()
     return Array.isArray(stats) ? (stats as Taostats) : []
   } catch (cause) {
-    throw new Error('Failed to fetch TAO stats', { cause })
+    console.error('Failed to fetch TAO stats', { cause })
   }
 })
 
@@ -42,7 +42,7 @@ export const taostatsByChainAtomFamily = atomFamily((genesisHash: string | undef
   const networkName = TaostatsNetworkByGenesisHash.get(genesisHash)
   if (!networkName) return atom(() => Promise.resolve(undefined))
 
-  return atom(async get => (await get(taostatsAtom)).find(stats => stats.network === networkName))
+  return atom(async get => (await get(taostatsAtom))?.find(stats => stats.network === networkName))
 })
 
 export const stakingAprByChainAtomFamily = atomFamily((genesisHash: string | undefined) =>

--- a/apps/portal/src/domains/staking/subtensor/hooks/useApr.ts
+++ b/apps/portal/src/domains/staking/subtensor/hooks/useApr.ts
@@ -6,5 +6,7 @@ export const useApr = (genesisHash: string | undefined) => {
 }
 
 export const useAprFormatted = (genesisHash: string | undefined) => {
-  return useApr(genesisHash).toLocaleString(undefined, { style: 'percent', maximumFractionDigits: 2 })
+  const apr = useApr(genesisHash)
+
+  return apr ? apr.toLocaleString(undefined, { style: 'percent', maximumFractionDigits: 2 }) : '--'
 }


### PR DESCRIPTION
# Description

Taostats api has changed and the endpoint we used has been depricated. Unfortunately the new API does not expose any endpoint that contains  `staking_apy` data and, so we will default APY to '--' in the meantime.

# Notes:

They will provide an API within this week or next according to [this conversation](https://discord.com/channels/1214123725788553266/1214124201712025671/1285179933940912188) in their [Discord channel](https://discord.gg/hSG3dmGr), then we need to update

### 🖼️ **Screenshots:**

![Screenshot 2024-09-17 at 10 20 55](https://github.com/user-attachments/assets/df6f599d-415e-4927-83a7-8309138680b6)
![Screenshot 2024-09-17 at 10 21 36](https://github.com/user-attachments/assets/4dcd8dbf-326b-4356-b1ae-517748ca4a7d)
