### PR TITLE
chore: re-enable-ksm-routes

### DIFF
--- a/apps/portal/src/domains/bridge/index.ts
+++ b/apps/portal/src/domains/bridge/index.ts
@@ -13,36 +13,6 @@ export const bridgeState = selector({
       adapters: Object.values(bridgeConfig)
         .filter((x): x is NonNullable<typeof x> => x !== undefined)
         .map(x => x.adapter),
-      disabledRouters: [
-        // Disable routes from asset hub
-        // due to reports of possible lost of funds from users
-        { from: 'assetHubPolkadot' },
-        // Temporarily disable Kusama routes
-        // due to: https://github.com/paritytech/polkadot-sdk/issues/3050
-        { from: 'altair' },
-        { from: 'kusama' },
-        { from: 'basilisk' },
-        { from: 'bifrost' },
-        { from: 'calamari' },
-        { from: 'crab' },
-        { from: 'khala' },
-        { from: 'kintsugi' },
-        { from: 'shiden' },
-        { from: 'shadow' },
-        { from: 'turing' },
-        { from: 'heiko' },
-        { from: 'integritee' },
-        { from: 'kico' },
-        { from: 'tinkernet' },
-        { from: 'listen' },
-        { from: 'pichiu' },
-        { from: 'quartz' },
-        { from: 'moonriver' },
-        { from: 'karura' },
-        { from: 'robonomics' },
-        { from: 'tinkernet' },
-        { from: 'assetHubKusama' },
-      ],
     })
     await bridge.isReady
     return bridge


### PR DESCRIPTION
### Description

Re-enabling Kusama XCM routes, since the problem was solved according to the issue on the comments.
I suppose there is also a way to recover trapped assets by now.