### PR TITLE
fix: network icons clipping

### DIFF
--- a/apps/portal/src/components/recipes/StakePosition/StakePosition.tsx
+++ b/apps/portal/src/components/recipes/StakePosition/StakePosition.tsx
@@ -289,14 +289,9 @@ const StakePosition = Object.assign(
 
               <span
                 css={{
-                  [MEDIUM_CONTAINER_QUERY]: {
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '1.2rem',
-                    overflow: 'hidden',
-                    whiteSpace: 'nowrap',
-                    textOverflow: 'ellipsis',
-                  },
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '1.2rem',
                 }}
               >
                 <AssetLogoWithChain assetLogoUrl={props.assetLogoSrc} chainId={props.chainId} />
@@ -305,6 +300,9 @@ const StakePosition = Object.assign(
                     display: 'contents',
                     [MEDIUM_CONTAINER_QUERY]: { display: 'none' },
                     [LARGE_CONTAINER_QUERY]: { display: 'contents' },
+                    overflow: 'hidden',
+                    whiteSpace: 'nowrap',
+                    textOverflow: 'ellipsis',
                   }}
                 >
                   <Text.Body as="div" alpha="high">

--- a/apps/portal/src/components/recipes/StakeProvider/StakeProvider.tsx
+++ b/apps/portal/src/components/recipes/StakeProvider/StakeProvider.tsx
@@ -88,14 +88,10 @@ const StakeProvider = Object.assign(
               display: 'flex',
               alignItems: 'center',
               gap: '1.2rem',
-              overflow: 'hidden',
-              whiteSpace: 'nowrap',
-              textOverflow: 'ellipsis',
             }}
           >
             <AssetLogoWithChain assetLogoUrl={props.logo} chainId={props.chainId ?? ''} />
-
-            <div>
+            <div className="truncate">
               <Text.Body as="div" alpha="high">
                 {props.symbol}
               </Text.Body>


### PR DESCRIPTION
# Description

Fixed:
- Network icons being clipped on the top on Stake Providers and Stake positions page
- Network icons being positioned far to the right on on Portfolio page and smaller screens

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x]  Ready to merge

### 🖼️ **Screenshots:**

![Screenshot 2024-10-15 at 15 35 18](https://github.com/user-attachments/assets/89125cb5-3c3c-476f-9b0a-3becac7ddcbd)
![Screenshot 2024-10-15 at 15 35 53](https://github.com/user-attachments/assets/c20a5b6e-e78f-4ba3-9c72-3cc295ab7467)
![Screenshot 2024-10-15 at 15 36 44](https://github.com/user-attachments/assets/001bd6fb-63af-4df4-b697-694bfd23022f)
