### PR TITLE
revert: "use kodadot ipfs gateway for Og wud burn collection"

### DIFF
--- a/apps/portal/src/routes/portfolio/collectibles.tsx
+++ b/apps/portal/src/routes/portfolio/collectibles.tsx
@@ -52,22 +52,14 @@ const NFT_CARD_WIDTH = 290
 
 const NftTagContext = createContext<NftTag | undefined>(undefined)
 
-const toIpfsCompatibleUrl = (url: string, options?: { imgWidth?: number }, nft?: Nft) => {
+const toIpfsCompatibleUrl = (url: string, options?: { imgWidth?: number }) => {
   const pattern = /ipfs:\/\/(ipfs\/)?/
 
   if (!url.match(pattern)) {
     return url
   }
 
-  const OG_WUD_BURN_COLLECTION_ID = '244'
-  const shouldUseKodadot = nft?.chain === 'polkadot-asset-hub' && nft.collection?.id === OG_WUD_BURN_COLLECTION_ID
-
-  const gatewayUrl = new URL(
-    url.replace(
-      /ipfs:\/\/(ipfs\/)?/,
-      shouldUseKodadot ? 'https://image.w.kodadot.xyz/ipfs/' : 'https://talisman.mypinata.cloud/ipfs/'
-    )
-  )
+  const gatewayUrl = new URL(url.replace(/ipfs:\/\/(ipfs\/)?/, 'https://talisman.mypinata.cloud/ipfs/'))
 
   if (options?.imgWidth !== undefined) {
     // x3 for high DPI display
@@ -122,8 +114,8 @@ const NftCard = ({ nft }: { nft: Nft }) => {
         media={
           <Card.Preview
             src={Maybe.of(nft.thumbnail ?? nft.media.url).mapOrUndefined(x => [
-              toIpfsCompatibleUrl(x, { imgWidth: NFT_CARD_WIDTH }, nft),
-              toIpfsCompatibleUrl(x, undefined, nft),
+              toIpfsCompatibleUrl(x, { imgWidth: NFT_CARD_WIDTH }),
+              toIpfsCompatibleUrl(x),
             ])}
             type={nft.thumbnail !== undefined ? undefined : (nft.media.mimeType?.split('/').at(0) as any)}
             fetchMime
@@ -237,8 +229,8 @@ const NftCollectionCard = ({ collection }: { collection: NftCollection }) => (
               <Card.Preview
                 key={nft.id}
                 src={Maybe.of(nft.thumbnail ?? nft.media.url).mapOrUndefined(x => [
-                  toIpfsCompatibleUrl(x, { imgWidth: NFT_CARD_WIDTH / 4 }, nft),
-                  toIpfsCompatibleUrl(x, undefined, nft),
+                  toIpfsCompatibleUrl(x, { imgWidth: NFT_CARD_WIDTH / 4 }),
+                  toIpfsCompatibleUrl(x),
                 ])}
                 fetchMime
               />

--- a/apps/portal/src/routes/portfolio/collectibles.tsx
+++ b/apps/portal/src/routes/portfolio/collectibles.tsx
@@ -164,8 +164,8 @@ const NftCard = ({ nft }: { nft: Nft }) => {
         overline={nft.collection?.name}
         media={
           <MediaDialog.Player
-            src={Maybe.of(nft.media.url).mapOrUndefined(x => toIpfsCompatibleUrl(x, undefined, nft))}
-            type={(nft.media.mimeType?.split('/').at(0) as any) ?? 'image'}
+            src={Maybe.of(nft.media.url).mapOrUndefined(toIpfsCompatibleUrl)}
+            type={nft.media.mimeType?.split('/').at(0) as any}
           />
         }
         content={


### PR DESCRIPTION
## Description

Closed original PR https://github.com/TalismanSociety/talisman-web/pull/1192 from @vikiival due to CI & CD issues for branches created from non-organisation members. An issue has been created to address this problem https://github.com/TalismanSociety/talisman-web/issues/1193

Thanks @vikiival!

Reverts TalismanSociety/talisman-web#1190 and TalismanSociety/talisman-web#1191

## Context 

Hey, we have found a root caused that caused this hiccup
as a responsible OSS we will publish a post-mortem.


## The fix

I am proposing to revert this PR as it was issue from our side and you do not need to have mess in your code. 

I already checked your gw - it is returning the images

[image](https://talisman.mypinata.cloud/ipfs/QmYUhpc4MHY8uZQiYLD7TBqLnqfKYFeuTgfzz9paAYsyVG)