### PR TITLE
chore: updated Bifrost unbonding period copy

### DIFF
--- a/apps/portal/src/components/widgets/staking/slpx/UnlockDuration.tsx
+++ b/apps/portal/src/components/widgets/staking/slpx/UnlockDuration.tsx
@@ -6,7 +6,7 @@ export type UnlockDurationProps = { slpxPair: SlpxPair }
 
 const UnlockDuration = (props: UnlockDurationProps) => {
   const unlockDuration = useVTokenUnlockDuration(props.slpxPair)
-  return <>{useMemo(() => formatDistance(0, unlockDuration), [unlockDuration])}</>
+  return <>0-{useMemo(() => formatDistance(0, unlockDuration), [unlockDuration])}</>
 }
 
 export default UnlockDuration

--- a/apps/portal/src/components/widgets/staking/slpxSubstrate/UnlockDuration.tsx
+++ b/apps/portal/src/components/widgets/staking/slpxSubstrate/UnlockDuration.tsx
@@ -11,7 +11,7 @@ const UnlockDuration = ({ slpxPair }: { slpxPair: SlpxSubstratePair }) => {
   const rounds = unlockDuration.unwrapOrDefault().toHuman().Era
   const duration = rounds * slpxPair.estimatedRoundDuration
 
-  return <>{formatDistance(0, Number(duration))}</>
+  return <>0-{formatDistance(0, Number(duration))}</>
 }
 
 export default UnlockDuration


### PR DESCRIPTION
# Description

Updated Bifrost's providers unbonding period to include "0" to X days, as there is not fixed term. 

## Type of change

- [x] Ready to merge
![Screenshot 2024-10-21 at 11 02 12](https://github.com/user-attachments/assets/952aa4fd-38fa-4cb7-aad9-9595e9fdc549)
![Screenshot 2024-10-21 at 11 02 47](https://github.com/user-attachments/assets/9e340751-9146-4117-8000-00ad70ae45b0)

