### PR TITLE
hotfix: added error boundary

### DIFF
--- a/apps/portal/src/components/recipes/StakePosition/StakePosition.tsx
+++ b/apps/portal/src/components/recipes/StakePosition/StakePosition.tsx
@@ -19,6 +19,7 @@ import { AccountIcon } from '@talismn/ui-recipes'
 import { ArrowDown, Clock, Earn, MoreHorizontal, ZapPlus } from '@talismn/web-icons'
 import React, { createContext, Suspense, useContext } from 'react'
 
+import ErrorBoundary from '@/components/widgets/ErrorBoundary'
 import { Account } from '@/domains/accounts/recoils'
 import { shortenAddress } from '@/util/format'
 
@@ -55,6 +56,21 @@ export type StakePositionProps = {
 }
 
 const StakePositionContext = createContext({ readonly: false })
+
+const CellErrorFallback = () => {
+  const theme = useTheme()
+  return (
+    <TonalButton
+      leadingIcon={<StakeStatusIndicator status={'not_nominating'} />}
+      css={{
+        backgroundColor: `color-mix(in srgb, ${theme.color.error}, transparent 95%)`,
+        color: theme.color.error,
+      }}
+    >
+      Loading Error
+    </TonalButton>
+  )
+}
 
 const IncreaseStakeButton = (props: Omit<IconButtonProps, 'children'>) => (
   <StakePositionContext.Consumer>
@@ -337,15 +353,17 @@ const StakePosition = Object.assign(
                 Total rewards (all time)
               </Text.BodySmall>
               <Text.Body as="div" alpha="high">
-                <Suspense fallback={<CircularProgressIndicator size="1em" />}>
-                  {props.rewards ?? <Text alpha="medium">--</Text>}
-                </Suspense>
-                <div css={{ display: 'none', [MEDIUM_CONTAINER_QUERY]: { display: 'revert' } }} />{' '}
-                <Suspense>
-                  <Text.Body alpha="medium" css={{ color: '#38D448' }}>
-                    {props.fiatRewards}
-                  </Text.Body>
-                </Suspense>
+                <ErrorBoundary renderFallback={() => <CellErrorFallback />}>
+                  <Suspense fallback={<CircularProgressIndicator size="1em" />}>
+                    {props.rewards ?? <Text alpha="medium">--</Text>}
+                  </Suspense>
+                  <div css={{ display: 'none', [MEDIUM_CONTAINER_QUERY]: { display: 'revert' } }} />{' '}
+                  <Suspense>
+                    <Text.Body alpha="medium" css={{ color: '#38D448' }}>
+                      {props.fiatRewards}
+                    </Text.Body>
+                  </Suspense>
+                </ErrorBoundary>
               </Text.Body>
             </section>
             <div css={{ [MEDIUM_CONTAINER_QUERY]: { width: '20rem', display: 'flex', justifyContent: 'start' } }}>


### PR DESCRIPTION
## Description

Created and error boundary for `Total rewards (all time)` Stake position column.

This way users can still interact with their pool if they wish 

## Screen Shots
![Screenshot 2024-10-26 at 23 25 38](https://github.com/user-attachments/assets/3eab2815-fd83-48cd-9632-8eee9026828d)
