### PR TITLE
refactor: updated Taostats api call endpoints

### DIFF
--- a/apps/portal/src/components/widgets/staking/subtensor/DelegateSelectorDialog.tsx
+++ b/apps/portal/src/components/widgets/staking/subtensor/DelegateSelectorDialog.tsx
@@ -1,11 +1,14 @@
+import { useState } from 'react'
+import { useRecoilValue_TRANSITION_SUPPORT_UNSTABLE as useRecoilValue } from 'recoil'
+
+import { useDelegatesStats } from '@/domains/staking/subtensor/hooks/useDelegatesStats'
+
+import type { Delegate } from '../../../../domains/staking/subtensor/atoms/delegates'
 import { useNativeTokenAmountState } from '../../../../domains/chains'
-import { DEFAULT_DELEGATE, type Delegate } from '../../../../domains/staking/subtensor/atoms/delegates'
+import { DEFAULT_DELEGATE } from '../../../../domains/staking/subtensor/atoms/delegates'
 import { useAllDelegateInfos } from '../../../../domains/staking/subtensor/hooks/useAllDelegateInfos'
 import { useDelegates } from '../../../../domains/staking/subtensor/hooks/useDelegates'
 import StakeTargetSelectorDialog from '../../../recipes/StakeTargetSelectorDialog'
-import { useDelegatesStats } from '@/domains/staking/subtensor/hooks/useDelegatesStats'
-import { useState } from 'react'
-import { useRecoilValue_TRANSITION_SUPPORT_UNSTABLE as useRecoilValue } from 'recoil'
 
 type DelegateSelectorDialogProps = {
   selected?: Delegate
@@ -36,8 +39,8 @@ export const DelegateSelectorDialog = (props: DelegateSelectorDialogProps) => {
           (b.props.balancePlanck ?? 0n) === (a.props.balancePlanck ?? 0n)
             ? 0
             : (b.props.balancePlanck ?? 0n) - (a.props.balancePlanck ?? 0n) < 0
-            ? -1
-            : 1,
+              ? -1
+              : 1,
         'Number of stakers': (a, b) =>
           parseInt(b.props.count?.toString?.() ?? '0') - parseInt(a.props.count?.toString?.() ?? '0'),
         'Estimated APR': (a, b) =>
@@ -53,7 +56,7 @@ export const DelegateSelectorDialog = (props: DelegateSelectorDialogProps) => {
     >
       {Object.values(delegates).map(delegate => {
         const formattedApr = Number(
-          delegatesStats.find(stat => stat.hot_key.ss58 === delegate.address)?.apr
+          delegatesStats.find(stat => stat.hotkey.ss58 === delegate.address)?.apr
         ).toLocaleString(undefined, { style: 'percent', maximumFractionDigits: 2 })
 
         return (

--- a/apps/portal/src/domains/staking/subtensor/atoms/taostats.ts
+++ b/apps/portal/src/domains/staking/subtensor/atoms/taostats.ts
@@ -1,15 +1,23 @@
-import { ValidatorsData } from '../types'
-import { delegatesAtom } from './delegates'
 import { atom } from 'jotai'
 import { atomFamily } from 'jotai/utils'
 
-const TAOSTATS_API_KEY = import.meta.env.REACT_APP_TAOSTATS_API_KEY
-const TAOSTATS_API_URL = 'https://api.taostats.io/api/v1'
+import { ValidatorsData } from '../types'
+import { delegatesAtom } from './delegates'
 
-const fetchTaoStats = async ({ page = 1, limit = 200 }: { page: number; limit: number }): Promise<ValidatorsData> => {
+const TAOSTATS_API_KEY = import.meta.env.REACT_APP_TAOSTATS_API_KEY
+const TAOSTATS_API_URL = 'https://api-prod-v2.taostats.io/api'
+const MAX_PAGE_SIZE = 100
+
+const fetchTaoStats = async ({
+  page = 1,
+  limit = MAX_PAGE_SIZE,
+}: {
+  page: number
+  limit: number
+}): Promise<ValidatorsData> => {
   try {
     return await (
-      await fetch(`${TAOSTATS_API_URL}/validator?page=${page}&limit=${limit}`, {
+      await fetch(`${TAOSTATS_API_URL}/validator/latest/v1?page=${page}&limit=${limit}`, {
         method: 'GET',
         headers: {
           Authorization: TAOSTATS_API_KEY,
@@ -23,14 +31,24 @@ const fetchTaoStats = async ({ page = 1, limit = 200 }: { page: number; limit: n
 }
 
 export const taostatsAtom = atom(async () => {
-  const stats: ValidatorsData = { count: 0, validators: [] }
-
+  const stats: ValidatorsData = {
+    pagination: {
+      current_page: 0,
+      per_page: 0,
+      total_items: 0,
+      total_pages: 0,
+      next_page: null,
+      prev_page: null,
+    },
+    data: [],
+  }
   let page = 1
-  while (stats.count === 0 || stats.count > stats.validators.length) {
-    const taoStats = await fetchTaoStats({ page: page, limit: 200 })
-    stats.count = taoStats.count
-    stats.validators.push(...taoStats.validators)
-    page++
+
+  while (!stats.data.length || stats.pagination.current_page < stats.pagination.total_pages) {
+    const taoStats = await fetchTaoStats({ page: page, limit: MAX_PAGE_SIZE })
+    stats.pagination = taoStats.pagination
+    stats.data.push(...taoStats.data)
+    page = taoStats.pagination.current_page + 1
   }
 
   return stats
@@ -42,21 +60,15 @@ export const activeTaoDelegatesStatsAtom = atom(async get => {
 
   const activeDelegatesHotKeys = Object.keys(delegates)
 
-  const activeDelegates = taostats.validators.filter(validator =>
-    activeDelegatesHotKeys.includes(validator.hot_key.ss58)
-  )
+  const activeDelegates = taostats.data.filter(validator => activeDelegatesHotKeys.includes(validator.hotkey.ss58))
 
   return activeDelegates
 })
 
 export const highestAprTaoValidatorAtom = atom(async get => {
   const activeDelegatesStats = await get(activeTaoDelegatesStatsAtom)
-  const highestAprValidatorStats = activeDelegatesStats.reduce((acc, validator) => {
-    if (parseFloat(validator.apr) > parseFloat(acc.apr)) {
-      acc = validator
-    }
-    return acc
-  })
+
+  const highestAprValidatorStats = activeDelegatesStats[0]
 
   return highestAprValidatorStats
 })
@@ -64,12 +76,12 @@ export const highestAprTaoValidatorAtom = atom(async get => {
 export const taoDelegateStatsAtomFamily = atomFamily((hotKey: string) =>
   atom(async get => {
     const activeDelegatesStats = await get(activeTaoDelegatesStatsAtom)
-    return activeDelegatesStats.find(validator => validator.hot_key.ss58 === hotKey)
+    return activeDelegatesStats.find(validator => validator.hotkey.ss58 === hotKey)
   })
 )
 
 export const taoTotalStakedTaoAtom = atom(async get => {
-  const { system_total_stake } = await get(highestAprTaoValidatorAtom)
+  const { system_stake = '0' } = (await get(highestAprTaoValidatorAtom)) ?? {}
 
-  return system_total_stake
+  return system_stake
 })

--- a/apps/portal/src/domains/staking/subtensor/hooks/useApr.ts
+++ b/apps/portal/src/domains/staking/subtensor/hooks/useApr.ts
@@ -1,9 +1,10 @@
-import { highestAprTaoValidatorAtom } from '../atoms/taostats'
-import { useDelegateStats } from './useDelegateStats'
 import { useAtomValue } from 'jotai'
 
+import { highestAprTaoValidatorAtom } from '../atoms/taostats'
+import { useDelegateStats } from './useDelegateStats'
+
 export const useHighestAprFormatted = () => {
-  const { apr } = useAtomValue(highestAprTaoValidatorAtom)
+  const { apr = '0' } = useAtomValue(highestAprTaoValidatorAtom) ?? {}
 
   return Number(apr).toLocaleString(undefined, { style: 'percent', maximumFractionDigits: 2 })
 }

--- a/apps/portal/src/domains/staking/subtensor/types.ts
+++ b/apps/portal/src/domains/staking/subtensor/types.ts
@@ -1,43 +1,59 @@
-export type ValidatorsData = {
-  count: number
-  validators: Validator[]
+type Pagination = {
+  current_page: number
+  per_page: number
+  total_items: number
+  total_pages: number
+  next_page: number | null
+  prev_page: number | null
 }
 
-type Validator = {
-  block_number: number
-  timestamp: string
-  registered_at_time: string
-  registered_at_block: number
-  validator_stake: string
-  amount: string
-  nominators: number
-  amount_change: string
-  nominator_change: number
-  registrations: number[]
-  validator_permits: number[]
-  total_daily_return: string
-  validator_return: string
-  nominator_return_per_k: string
-  apr: string
-  apr_7_day_average: string
-  apr_30_day_average: string
-  hot_key: Key
-  cold_key: Key
-  take: string
-  rank: number
-  dominance: string
-  system_total_stake: string
-  nominator_7day_average: string
-  nominator_30day_average: string
-  subnet_dominance: SubnetDominance[]
-}
-
+// Key Type
 type Key = {
   ss58: string
   hex: string
 }
 
+// Subnet Dominance Type
 type SubnetDominance = {
   netuid: number
   dominance: string
+  family_stake: string
+}
+
+// Validator Data Type
+type ValidatorData = {
+  hotkey: Key
+  coldkey: Key
+  name: string
+  block_number: number
+  timestamp: string // ISO date format string
+  rank: number
+  nominators: number
+  nominators_24_hr_change: number
+  system_stake: string
+  stake: string
+  stake_24_hr_change: string
+  dominance: string
+  validator_stake: string
+  take: string
+  total_daily_return: string
+  validator_return: string
+  nominator_return_per_k: string
+  apr: string
+  nominator_return_per_k_7_day_average: string
+  nominator_return_per_k_30_day_average: string
+  apr_7_day_average: string
+  apr_30_day_average: string
+  pending_emission: string
+  blocks_until_next_reward: number
+  last_reward_block: number
+  registrations: number[]
+  permits: number[]
+  subnet_dominance: SubnetDominance[]
+}
+
+// API Response Type
+export type ValidatorsData = {
+  pagination: Pagination
+  data: ValidatorData[]
 }


### PR DESCRIPTION
# Description

Updated Taostats api calls and response parsing to match upcoming changes. See [docs](https://docs.taostats.io/reference/get-validator).

##  Attention ⚠️ 

Update the API URL between November 1st and **_before_** December 1st. Check [import API Updates](https://docs.taostats.io/reference/important-api-updates) for more details


## Type of change

Please delete options that are not relevant.

- [x] Ready to merge

### 🧪 **How to test:**
- Visit `/staking/providers`
Expected: Est. return should be displayed

- Click on "stake" on TAO row
Expected: Total Staked should display selected currency amount, or TAO amount when currency price is not available. Estimated APR should be displayed

- Click on Select Delegate
Expected: Estimated APR should be displayed and sorting by Estimated APR should work 

### 🖼️ **Screenshots:**


https://github.com/user-attachments/assets/955e3cea-b574-4195-9e3d-71f7a411b7d3


