### PR TITLE
fix: some portfolio icon bugs

### DIFF
--- a/apps/portal/src/components/legacy/archetypes/Portfolio/Assets.tsx
+++ b/apps/portal/src/components/legacy/archetypes/Portfolio/Assets.tsx
@@ -1,10 +1,11 @@
-import { balancesState, selectedBalancesState, selectedCurrencyState } from '../../../../domains/balances'
 import { BalanceFormatter } from '@talismn/balances'
 import { useChains, useEvmNetworks, useTokenRates, useTokens } from '@talismn/balances-react'
 import { formatDecimals } from '@talismn/util'
-import { compact, groupBy, isEmpty, isNil, startCase } from 'lodash'
+import { compact, groupBy, isEmpty, isNil } from 'lodash'
 import { useMemo } from 'react'
 import { useRecoilValue } from 'recoil'
+
+import { balancesState, selectedBalancesState, selectedCurrencyState } from '@/domains/balances'
 
 const useFetchAssets = (address: string | undefined) => {
   const _balances = useRecoilValue(address === undefined ? selectedBalancesState : balancesState)
@@ -110,8 +111,6 @@ const useAssets = (customAddress?: string) => {
 
         const locked = lockedAmount > 0n
 
-        const tokenDisplayName = startCase(token.coingeckoId)
-
         return {
           stale: tokenBalances.each.some(x => x.status === 'stale'),
           locked,
@@ -135,7 +134,6 @@ const useAssets = (customAddress?: string) => {
               : token.evmNetwork
               ? evmNetworks[token.evmNetwork.id]
               : undefined,
-            tokenDisplayName,
           },
           // if the token is substrate-native then make it an array else make it undefined
           nonNativeTokens: [],

--- a/apps/portal/src/components/recipes/Asset/Asset.tsx
+++ b/apps/portal/src/components/recipes/Asset/Asset.tsx
@@ -1,14 +1,18 @@
-import type { PortfolioToken } from '../../legacy/archetypes/Portfolio/Assets'
-import AnimatedFiatNumber from '../../widgets/AnimatedFiatNumber'
-import RedactableBalance from '../../widgets/RedactableBalance'
+import type { ReactElement, ReactNode } from 'react'
 import { keyframes } from '@emotion/react'
 import styled from '@emotion/styled'
 import { type Balances } from '@talismn/balances'
+import { githubUnknownChainLogoUrl, githubUnknownTokenLogoUrl } from '@talismn/chaindata-provider'
 import { HiddenDetails, Text, Tooltip, useSurfaceColor } from '@talismn/ui'
 import { AlertTriangle, Lock } from '@talismn/web-icons'
-import { isEmpty, startCase } from 'lodash'
-import { Children, type ReactElement, type ReactNode } from 'react'
+import { isEmpty } from 'lodash'
+import { Children } from 'react'
 import { useNavigate } from 'react-router-dom'
+
+import type { PortfolioToken } from '@/components/legacy/archetypes/Portfolio/Assets'
+import { AssetLogoWithChain } from '@/components/recipes/AssetLogoWithChain'
+import AnimatedFiatNumber from '@/components/widgets/AnimatedFiatNumber'
+import RedactableBalance from '@/components/widgets/RedactableBalance'
 
 type AssetBalanceProps = {
   planck: string
@@ -41,26 +45,26 @@ export const AssetBalance = ({ planck, fiat, symbol, locked, stale }: AssetBalan
         <Text.Body
           alpha={locked ? 'medium' : 'high'}
           css={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.25em',
             margin: 0,
             fontSize: '16px',
           }}
         >
           <RedactableBalance>{planck ? `${planck} ${symbol} ` : '- ' + symbol}</RedactableBalance>
           {stale && (
-            <>
-              {' '}
-              <Tooltip
-                content={
-                  <>
-                    Latest balance not available.
-                    <br />
-                    Displayed value may be out of date.
-                  </>
-                }
-              >
-                <AlertTriangle size="0.75em" css={{ color: '#FD8FFF', verticalAlign: 'baseline' }} />
-              </Tooltip>
-            </>
+            <Tooltip
+              content={
+                <>
+                  Latest balance not available.
+                  <br />
+                  Displayed value may be out of date.
+                </>
+              }
+            >
+              <AlertTriangle size="0.75em" css={{ color: '#FD8FFF', verticalAlign: 'baseline' }} />
+            </Tooltip>
           )}
         </Text.Body>
         {locked ? <Lock css={{ width: '16px', height: '16px' }} /> : ''}
@@ -222,18 +226,10 @@ const Asset = Object.assign((props: AssetProps) => {
       <td valign="top">
         {/* First Column */}
         <div css={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
-          <Tooltip content={startCase(token.tokenDetails.chain?.id ?? token.tokenDetails.coingeckoId)}>
-            <img
-              src={token.tokenDetails.logo}
-              css={{
-                width: '2em',
-                height: '2em',
-                margin: '16px',
-                borderRadius: '50%',
-              }}
-              alt="logo"
-            />
-          </Tooltip>
+          <AssetLogoWithChain
+            className="m-[8px] text-[32px] sm:text-[32px]"
+            assetLogoUrl={token.tokenDetails.logo ?? githubUnknownTokenLogoUrl}
+          />
           <div>
             <div css={{ display: 'flex', alignItems: 'center', gap: '0.4em' }}>
               <Text.Body alpha="high" css={{ fontWeight: 600, fontSize: '16px' }}>
@@ -250,11 +246,11 @@ const Asset = Object.assign((props: AssetProps) => {
                 }}
               >
                 <div css={{ width: '1em', height: '1em' }}>
-                  <Tooltip content={startCase(token.tokenDetails.chain?.id ?? token.tokenDetails.coingeckoId)}>
+                  <Tooltip content={token.tokenDetails.chain?.name ?? undefined}>
                     <img
-                      src={token.tokenDetails.logo}
+                      src={token.tokenDetails.chain?.logo ?? githubUnknownChainLogoUrl}
                       css={{ width: '100%', height: '100%', borderRadius: '50%' }}
-                      alt={token.tokenDetails.tokenDisplayName ?? '' + ' logo'}
+                      alt={token.tokenDetails.chain?.name ?? '' + ' logo'}
                     />
                   </Tooltip>
                 </div>

--- a/apps/portal/src/components/recipes/AssetBreakdown/AssetBreakdownList.tsx
+++ b/apps/portal/src/components/recipes/AssetBreakdown/AssetBreakdownList.tsx
@@ -1,11 +1,14 @@
-import { selectedAccountsState } from '../../../domains/accounts/recoils'
-import { selectedCurrencyState } from '../../../domains/balances'
-import type { PortfolioToken } from '../../legacy/archetypes/Portfolio/Assets'
-import { AssetBreakdownRow, AssetBreakdownRowHeader } from './AssetBreakdownRow'
+import type { Balances } from '@talismn/balances'
 import styled from '@emotion/styled'
-import { BalanceFormatter, type Balances } from '@talismn/balances'
+import { BalanceFormatter } from '@talismn/balances'
 import { formatDecimals } from '@talismn/util'
 import { useRecoilValue, waitForAll } from 'recoil'
+
+import type { PortfolioToken } from '@/components/legacy/archetypes/Portfolio/Assets'
+import { selectedAccountsState } from '@/domains/accounts/recoils'
+import { selectedCurrencyState } from '@/domains/balances'
+
+import { AssetBreakdownRow, AssetBreakdownRowHeader } from './AssetBreakdownRow'
 
 const Table = styled.table`
   width: 100%;

--- a/apps/portal/src/components/recipes/AssetBreakdown/AssetBreakdownRow.tsx
+++ b/apps/portal/src/components/recipes/AssetBreakdown/AssetBreakdownRow.tsx
@@ -1,11 +1,13 @@
-import { type Account } from '../../../domains/accounts/recoils'
-import type { PortfolioToken } from '../../legacy/archetypes/Portfolio/Assets'
-import AccountIcon from '../../molecules/AccountIcon/AccountIcon'
-import { AssetBalance } from '../Asset'
 import { keyframes } from '@emotion/react'
 import styled from '@emotion/styled'
+import { githubUnknownChainLogoUrl } from '@talismn/chaindata-provider'
 import { Text, Tooltip } from '@talismn/ui'
 import { startCase } from 'lodash'
+
+import type { PortfolioToken } from '@/components/legacy/archetypes/Portfolio/Assets'
+import AccountIcon from '@/components/molecules/AccountIcon/AccountIcon'
+import { AssetBalance } from '@/components/recipes/Asset'
+import { type Account } from '@/domains/accounts/recoils'
 
 const slideDown = keyframes`
     from {
@@ -36,7 +38,7 @@ export const AssetBreakdownRowHeader = ({ token }: { token: PortfolioToken }) =>
         >
           <Tooltip content={token.tokenDetails.chain?.name}>
             <img
-              src={token.tokenDetails.chain?.logo ?? undefined}
+              src={token.tokenDetails.chain?.logo ?? githubUnknownChainLogoUrl}
               alt={token.tokenDetails.chain?.name ?? undefined}
               css={{
                 width: '2em',

--- a/apps/portal/src/routes/portfolio/assets/item.tsx
+++ b/apps/portal/src/routes/portfolio/assets/item.tsx
@@ -1,12 +1,14 @@
-import { useSingleAsset } from '../../../components/legacy/archetypes/Portfolio/Assets'
-import { AssetBreakdownList } from '../../../components/recipes/AssetBreakdown/AssetBreakdownList'
-import AnimatedFiatNumber from '../../../components/widgets/AnimatedFiatNumber'
-import RedactableBalance from '../../../components/widgets/RedactableBalance'
 import { keyframes } from '@emotion/react'
-import { Button, HiddenDetails, InfoCard, Text, Tooltip } from '@talismn/ui'
+import { githubUnknownTokenLogoUrl } from '@talismn/chaindata-provider'
+import { Button, HiddenDetails, InfoCard, Text } from '@talismn/ui'
 import { ChevronLeft } from '@talismn/web-icons'
-import { startCase } from 'lodash'
 import { useNavigate, useParams } from 'react-router-dom'
+
+import { useSingleAsset } from '@/components/legacy/archetypes/Portfolio/Assets'
+import { AssetBreakdownList } from '@/components/recipes/AssetBreakdown/AssetBreakdownList'
+import { AssetLogoWithChain } from '@/components/recipes/AssetLogoWithChain'
+import AnimatedFiatNumber from '@/components/widgets/AnimatedFiatNumber'
+import RedactableBalance from '@/components/widgets/RedactableBalance'
 
 const slideDown = keyframes`
     from {
@@ -81,17 +83,10 @@ const AssetItem = () => {
                       alignItems: 'center',
                     }}
                   >
-                    <Tooltip content={startCase(token.tokenDetails.chain?.id ?? token.tokenDetails.coingeckoId)}>
-                      <img
-                        src={token.tokenDetails.logo}
-                        css={{
-                          width: '1em',
-                          height: '1em',
-                        }}
-                        alt={token.tokenDetails.chain?.id ?? (token.tokenDetails.coingeckoId ?? '') + ' logo'}
-                      />
-                    </Tooltip>
-                    <Text.Body alpha="high">{token.tokenDetails.tokenDisplayName}</Text.Body>
+                    <AssetLogoWithChain
+                      className="text-[1em] sm:text-[1em]"
+                      assetLogoUrl={token.tokenDetails.logo ?? githubUnknownTokenLogoUrl}
+                    />
                     <Text.Body>{`(${token.tokenDetails.symbol ?? ''})`}</Text.Body>
                   </div>
                 }


### PR DESCRIPTION
Fixes:
- Don't add border-radius to chaindata icons
- Don't show chain name/id where only token is shown (and thus many chains are relevant)
- Alert triangle should be inline with balance