### PR TITLE
refactor: close side sheet on tx success - Slpx

### DIFF
--- a/apps/portal/src/components/recipes/AddStakeDialog/AddStakeDialog.tsx
+++ b/apps/portal/src/components/recipes/AddStakeDialog/AddStakeDialog.tsx
@@ -1,5 +1,5 @@
-import { AlertDialog, Button, Text, TextInput } from '@talismn/ui'
 import type { ReactNode } from 'react'
+import { AlertDialog, Button, Text, TextInput } from '@talismn/ui'
 
 export type AddStakeFormProps = {
   accountSelector?: ReactNode
@@ -66,7 +66,7 @@ const AddStakeForm = (props: AddStakeFormProps) => (
       loading={props.confirmState === 'pending'}
       css={{ width: '100%', marginTop: '4.6rem' }}
     >
-      {props.approvalNeeded ? 'Approve' : 'Stake'}
+      {props.approvalNeeded ? 'Approve Spend' : 'Stake'}
     </Button>
   </div>
 )

--- a/apps/portal/src/components/recipes/UnstakeDialog/UnstakeDialog.tsx
+++ b/apps/portal/src/components/recipes/UnstakeDialog/UnstakeDialog.tsx
@@ -1,5 +1,6 @@
+import type { ReactNode } from 'react'
 import { AlertDialog, Button, CircularProgressIndicator, Text, TextInput } from '@talismn/ui'
-import { Suspense, type ReactNode } from 'react'
+import { Suspense } from 'react'
 
 export type UnstakeDialogProps = {
   open?: boolean
@@ -100,7 +101,7 @@ export const NominationPoolsUnstakeDialog = (props: NominationPoolsUnstakeDialog
 type SlpxUnstakeDialogProps = UnstakeDialogProps & { approvalNeeded?: boolean }
 
 export const SlpxUnstakeDialog = (props: SlpxUnstakeDialogProps) => (
-  <UnstakeDialog {...props} buttonText={props.approvalNeeded ? 'Approve' : undefined} />
+  <UnstakeDialog {...props} buttonText={props.approvalNeeded ? 'Approve Spend' : undefined} />
 )
 
 export default UnstakeDialog

--- a/apps/portal/src/components/widgets/staking/slpx/StakeSideSheet.tsx
+++ b/apps/portal/src/components/widgets/staking/slpx/StakeSideSheet.tsx
@@ -115,7 +115,7 @@ const AddStakeSideSheet = (props: AddStakeSideSheetProps) => {
             if (approvalNeeded) {
               await approve.writeContractAsync()
             } else {
-              await mint.writeContractAsync()
+              await mint.writeContractAsync().then(() => props.onRequestDismiss())
             }
           }}
           onRequestMaxAmount={() => {

--- a/apps/portal/src/components/widgets/staking/slpxSubstrate/AddStakeSideSheet.tsx
+++ b/apps/portal/src/components/widgets/staking/slpxSubstrate/AddStakeSideSheet.tsx
@@ -11,7 +11,6 @@ import {
 import { Clock, Zap } from '@talismn/web-icons'
 import { formatDistance } from 'date-fns'
 import { Suspense } from 'react'
-import { useNavigate } from 'react-router-dom'
 import { useRecoilValue } from 'recoil'
 
 import { useSlpxAprState } from '@/domains/staking/slpx'
@@ -29,7 +28,6 @@ type Props = {
 }
 
 const AddStakeSideSheet = ({ slpxPair, onRequestDismiss }: Props) => {
-  const navigate = useNavigate()
   const [[account], accountSelector] = useAccountSelector(useRecoilValue(writeableSubstrateAccountsState), 0)
 
   const { amount, setAmount, availableBalance, rate, newStakedTotal, extrinsic, error } = useStakeAddForm({
@@ -83,7 +81,7 @@ const AddStakeSideSheet = ({ slpxPair, onRequestDismiss }: Props) => {
           onChangeAmount={setAmount}
           availableToStake={amountAvailable.toLocaleString()}
           rate={`1 ${slpxPair.nativeToken.symbol} = ${rate.toLocaleString()} ${slpxPair.vToken.symbol}`}
-          onConfirm={() => extrinsic?.signAndSend(account?.address ?? '').then(() => navigate('/staking/positions'))}
+          onConfirm={() => extrinsic?.signAndSend(account?.address ?? '').then(() => onRequestDismiss())}
           onRequestMaxAmount={() => {
             if (amountAfterFee !== undefined && amountAfterFee.planck > 0) {
               setAmount(amountAfterFee.toString())

--- a/apps/portal/src/domains/staking/slpx/core.ts
+++ b/apps/portal/src/domains/staking/slpx/core.ts
@@ -253,10 +253,7 @@ export const useSlpxSwapForm = (
 }
 
 export const useRedeemForm = (account: Account | undefined, slpxPair: SlpxPair) => {
-  if (!account?.address) {
-    throw new Error('Account address is required')
-  }
-  if (!isAddress(account.address)) {
+  if (account?.address !== undefined && !isAddress(account.address)) {
     throw new Error(`Invalid EVM address ${account.address}`)
   }
 
@@ -292,7 +289,7 @@ export const useRedeemForm = (account: Account | undefined, slpxPair: SlpxPair) 
         slpxPair.vToken.address,
         planckAmount ?? 0n,
         BigInt(slpxPair.chain.id),
-        account.address as `0x${string}`,
+        account?.address as `0x${string}`,
         remark,
         channel_id,
       ],
@@ -363,11 +360,7 @@ export const useRedeemForm = (account: Account | undefined, slpxPair: SlpxPair) 
 }
 
 export const useMintForm = (account: Account | undefined, slpxPair: SlpxPair) => {
-  if (!account?.address) {
-    throw new Error('Account address is required')
-  }
-
-  if (!isAddress(account.address)) {
+  if (account?.address !== undefined && !isAddress(account.address)) {
     throw new Error(`Invalid EVM address ${account.address}`)
   }
 


### PR DESCRIPTION
# Description

- fix: do not throw if no eth account is connected
- close side sheet on tx success
- updated approve copy to Approve Spend

### 🖼️ **Screenshots:**


https://github.com/user-attachments/assets/bc43981a-36ac-4a46-9496-3e6c6c0c6c24

