### PR TITLE
feat: Display staking providers by position

### DIFF
--- a/apps/portal/src/components/widgets/staking/providers/components/StakeProvidersTable.tsx
+++ b/apps/portal/src/components/widgets/staking/providers/components/StakeProvidersTable.tsx
@@ -17,6 +17,7 @@ import { Link } from 'react-router-dom'
 
 import { ErrorBoundary } from '@/components/widgets/ErrorBoundary'
 import ErrorBoundaryFallback from '@/components/widgets/staking/ErrorBoundaryFallback'
+import { getPosition } from '@/domains/staking/utils/getPosition'
 import { cn } from '@/util/cn'
 
 import { Provider } from '../hooks/types'
@@ -37,6 +38,16 @@ const StakeProvidersTable = ({ dataQuery }: StakeProviderProps) => {
   const [sorting, setSorting] = useState<SortingState>([])
   const { getValuesForSortType, setValues } = useStakeValues()
 
+  const sortedData = useMemo(() => {
+    if (!dataQuery) return []
+    return [...dataQuery].sort((a, b) => {
+      // Ascending order by position
+      const aPosition = getPosition({ providerName: a.provider, tokenSymbol: a.nativeToken?.symbol })
+      const bPosition = getPosition({ providerName: b.provider, tokenSymbol: b.nativeToken?.symbol })
+      return aPosition - bPosition
+    })
+  }, [dataQuery])
+
   // Generic sorting function that sorts based on the provided sort type
   const sortingFn = useCallback(
     (sortType: StakeType) => (rowA: { id: string | number }, rowB: { id: string | number }) => {
@@ -47,8 +58,6 @@ const StakeProvidersTable = ({ dataQuery }: StakeProviderProps) => {
     },
     [getValuesForSortType]
   )
-
-  const defaultData = useMemo(() => [], [])
 
   const columns = useMemo<ColumnDef<Provider>[]>(
     () => [
@@ -173,7 +182,7 @@ const StakeProvidersTable = ({ dataQuery }: StakeProviderProps) => {
   }))
 
   const table = useReactTable({
-    data: dataQuery ?? defaultData,
+    data: sortedData,
     columns,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),

--- a/apps/portal/src/components/widgets/staking/providers/hooks/types.ts
+++ b/apps/portal/src/components/widgets/staking/providers/hooks/types.ts
@@ -29,4 +29,5 @@ export type Provider = {
   genesisHash: `0x${string}`
   apiEndpoint?: string
   tokenPair?: SlpxPair | SlpxSubstratePair
+  position?: string
 }

--- a/apps/portal/src/domains/staking/utils/getPosition.ts
+++ b/apps/portal/src/domains/staking/utils/getPosition.ts
@@ -1,0 +1,29 @@
+/**
+ * To add a position to a provider use the following patter:
+ * providerName_tokenSymbol: position
+ */
+const position: Record<string, number> = {
+  polkadot_dot: 0,
+  bittensor_tao: 1,
+  kusama_ksm: 2,
+  aleph_zero_azero: 3,
+  vara_vara: 4,
+  avail_avail: 5,
+  cere_cere: 6,
+  bifrost_slpx_manta: 7,
+  bifrost_slpx_glmr: 8,
+  bifrost_slpx_dot: 9,
+  lido_eth: 10,
+  astar_astar: 11,
+}
+
+export const getPosition = ({
+  providerName,
+  tokenSymbol,
+}: {
+  providerName: string | undefined
+  tokenSymbol: string | undefined
+}) => {
+  const provider = providerName?.trim().replace(/\s+/g, '_').toLowerCase()
+  return position[`${provider}_${tokenSymbol?.toLowerCase()}`] ?? 99
+}


### PR DESCRIPTION
# Description

- Default order Stake providers by curated position
- Reposition TAO as 2nd provider of the list

### 🖼️ **Screenshots:** 
![Screenshot 2025-01-14 at 16 35 18](https://github.com/user-attachments/assets/4d5f96e0-cdd7-462d-b839-db70e53c6458)
