### PR TITLE
feat: support rootnet subnet staking

### DIFF
--- a/apps/portal/src/components/widgets/staking/subtensor/constants.ts
+++ b/apps/portal/src/components/widgets/staking/subtensor/constants.ts
@@ -1,0 +1,1 @@
+export const ROOT_NETUID = 0

--- a/apps/portal/src/domains/staking/subtensor/atoms/accountStake.ts
+++ b/apps/portal/src/domains/staking/subtensor/atoms/accountStake.ts
@@ -45,7 +45,7 @@ export const accountStakeAtom = atomFamily(
             coldkey,
             hotkey,
             // make every stake a `bigint`, instead of a `number | bigint`, for consistency
-            stake: typeof stake === 'number' ? BigInt(stake) : stake,
+            stake: BigInt(stake),
           }))
           .filter(({ stake }) => stake !== 0n)
 
@@ -64,6 +64,7 @@ export const accountStakeAtom = atomFamily(
             coldkey,
             hotkey,
             netuid: BigInt(netuid),
+            // make every stake a `bigint`, instead of a `number | bigint`, for consistency
             stake: BigInt(stake),
           }))
           .filter(({ stake }) => stake !== 0n)

--- a/apps/portal/src/domains/staking/subtensor/atoms/accountStake.ts
+++ b/apps/portal/src/domains/staking/subtensor/atoms/accountStake.ts
@@ -3,6 +3,8 @@ import { atom } from 'jotai'
 import { atomFamily } from 'jotai/utils'
 import { compact, Struct, Vector } from 'scale-ts'
 
+import { ROOT_NETUID } from '@/components/widgets/staking/subtensor/constants'
+
 import { BittensorAccountId, vecDecodeResult, vecEncodeParams } from './_types'
 
 const StakeInfo = Struct({
@@ -10,6 +12,17 @@ const StakeInfo = Struct({
   coldkey: BittensorAccountId,
   stake: compact,
 })
+
+type DTaoStakeInfo = {
+  coldkey: string
+  hotkey: string
+  netuid: string
+  stake: string
+  drain: string
+  emission: string
+  isRegistered: boolean
+  locked: string
+}
 
 const EncodeParams_GetStakeInfoForColdkey = (address: string) => vecEncodeParams(BittensorAccountId.enc(address))
 const DecodeResult_GetStakeInfoForColdkey = (result: string) => Vector(StakeInfo).dec(vecDecodeResult(result))
@@ -35,10 +48,25 @@ export const accountStakeAtom = atomFamily(
         if (stakes?.length === 0) return undefined
         return stakes
       } catch (cause) {
-        console.error(
-          new Error(`Failed to fetch subtensor stake for account ${address} on chain ${api.genesisHash}`, { cause })
-        )
-        return undefined
+        const response = (
+          await api.call['stakeInfoRuntimeApi']?.['getStakeInfoForColdkey']?.(address)
+        )?.toHuman() as DTaoStakeInfo[]
+
+        if (!Array.isArray(response)) return undefined
+
+        const stakes = response
+          // Filter out Subnet stakes for now
+          .filter(stake => Number(stake?.netuid) === ROOT_NETUID)
+          ?.map(({ coldkey, hotkey, stake, netuid }) => ({
+            coldkey,
+            hotkey,
+            netuid,
+            stake: BigInt(Number(stake.replace(/,/g, ''))),
+          }))
+          .filter(({ stake }) => stake !== 0n)
+
+        if (stakes?.length === 0) return undefined
+        return stakes
       }
     }),
 

--- a/apps/portal/src/domains/staking/subtensor/atoms/accountStake.ts
+++ b/apps/portal/src/domains/staking/subtensor/atoms/accountStake.ts
@@ -1,39 +1,43 @@
+import { toHex } from '@polkadot-api/utils'
 import { ApiPromise } from '@polkadot/api'
 import { atom } from 'jotai'
 import { atomFamily } from 'jotai/utils'
-import { compact, Struct, Vector } from 'scale-ts'
+import { bool, compact, Struct, Vector } from 'scale-ts'
 
 import { ROOT_NETUID } from '@/components/widgets/staking/subtensor/constants'
 
 import { BittensorAccountId, vecDecodeResult, vecEncodeParams } from './_types'
 
-const StakeInfo = Struct({
+/** For encoding/decoding the GetStakeInfoForColdkey runtime api *before* they added the netuid parameter */
+const StakeInfo_old = Struct({
   hotkey: BittensorAccountId,
   coldkey: BittensorAccountId,
   stake: compact,
 })
+const EncodeParams_old_GetStakeInfoForColdkey = (address: string) => vecEncodeParams(BittensorAccountId.enc(address))
+const DecodeResult_old_GetStakeInfoForColdkey = (result: string) => Vector(StakeInfo_old).dec(vecDecodeResult(result))
 
-type DTaoStakeInfo = {
-  coldkey: string
-  hotkey: string
-  netuid: string
-  stake: string
-  drain: string
-  emission: string
-  isRegistered: boolean
-  locked: string
-}
-
-const EncodeParams_GetStakeInfoForColdkey = (address: string) => vecEncodeParams(BittensorAccountId.enc(address))
-const DecodeResult_GetStakeInfoForColdkey = (result: string) => Vector(StakeInfo).dec(vecDecodeResult(result))
+/** For encoding/decoding the GetStakeInfoForColdkey runtime api *after* they added the netuid parameter */
+const StakeInfo = Struct({
+  hotkey: BittensorAccountId,
+  coldkey: BittensorAccountId,
+  netuid: compact,
+  stake: compact,
+  locked: compact,
+  emission: compact,
+  drain: compact,
+  isRegistered: bool,
+})
+const EncodeParams_GetStakeInfoForColdkey = (address: string) => toHex(BittensorAccountId.enc(address))
+const DecodeResult_GetStakeInfoForColdkey = (result: string) => Vector(StakeInfo).dec(result)
 
 export const accountStakeAtom = atomFamily(
   ({ api, address }: { api: ApiPromise; address: string }) =>
     atom(async () => {
       try {
-        const params = EncodeParams_GetStakeInfoForColdkey(address)
+        const params = EncodeParams_old_GetStakeInfoForColdkey(address)
         const response = (await api.rpc.state.call('StakeInfoRuntimeApi_get_stake_info_for_coldkey', params)).toHex()
-        const result = DecodeResult_GetStakeInfoForColdkey(response)
+        const result = DecodeResult_old_GetStakeInfoForColdkey(response)
         if (!Array.isArray(result)) return undefined
 
         const stakes = result
@@ -48,20 +52,19 @@ export const accountStakeAtom = atomFamily(
         if (stakes?.length === 0) return undefined
         return stakes
       } catch (cause) {
-        const response = (
-          await api.call['stakeInfoRuntimeApi']?.['getStakeInfoForColdkey']?.(address)
-        )?.toHuman() as DTaoStakeInfo[]
+        const params = EncodeParams_GetStakeInfoForColdkey(address)
+        const response = (await api.rpc.state.call('StakeInfoRuntimeApi_get_stake_info_for_coldkey', params)).toHex()
+        const result = DecodeResult_GetStakeInfoForColdkey(response)
+        if (!Array.isArray(result)) return undefined
 
-        if (!Array.isArray(response)) return undefined
-
-        const stakes = response
+        const stakes = result
           // Filter out Subnet stakes for now
-          .filter(stake => Number(stake?.netuid) === ROOT_NETUID)
-          ?.map(({ coldkey, hotkey, stake, netuid }) => ({
+          .filter(stake => stake.netuid === ROOT_NETUID)
+          ?.map(({ coldkey, hotkey, netuid, stake }) => ({
             coldkey,
             hotkey,
-            netuid,
-            stake: BigInt(Number(stake.replace(/,/g, ''))),
+            netuid: BigInt(netuid),
+            stake: BigInt(stake),
           }))
           .filter(({ stake }) => stake !== 0n)
 

--- a/apps/portal/src/domains/staking/subtensor/hooks/forms.ts
+++ b/apps/portal/src/domains/staking/subtensor/hooks/forms.ts
@@ -23,10 +23,6 @@ export const useAddStakeForm = (account: Account, stake: Stake, delegate: string
   const [input, setInput] = useState('')
   const amount = useTokenAmount(input)
 
-  const apiEndpoint = useSubstrateApiEndpoint()
-
-  console.log(`apiEndpoint: ${apiEndpoint}`)
-
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const tx: SubmittableExtrinsic<any> = useMemo(() => {
     try {

--- a/apps/portal/src/domains/staking/subtensor/hooks/forms.ts
+++ b/apps/portal/src/domains/staking/subtensor/hooks/forms.ts
@@ -5,6 +5,7 @@ import { useMemo, useState } from 'react'
 import { useRecoilValue, useRecoilValueLoadable, waitForAll } from 'recoil'
 
 import type { Account } from '@/domains/accounts/recoils'
+import { ROOT_NETUID } from '@/components/widgets/staking/subtensor/constants'
 import { useExtrinsic } from '@/domains/common/hooks/useExtrinsic'
 import { useSubstrateApiEndpoint } from '@/domains/common/hooks/useSubstrateApiEndpoint'
 import { useSubstrateApiState } from '@/domains/common/hooks/useSubstrateApiState'
@@ -13,8 +14,6 @@ import { paymentInfoState } from '@/domains/common/recoils'
 
 import { MIN_SUBTENSOR_STAKE } from '../atoms/delegates'
 import { type Stake } from './useStake'
-
-const MAINNET_NETUID = 0
 
 export const useAddStakeForm = (account: Account, stake: Stake, delegate: string) => {
   const [api, [accountInfo]] = useRecoilValue(
@@ -39,7 +38,7 @@ export const useAddStakeForm = (account: Account, stake: Stake, delegate: string
     } catch {
       return api.tx.utility.batchAll([
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (api.tx as any)?.subtensorModule?.addStake?.(delegate, MAINNET_NETUID, amount.decimalAmount?.planck ?? 0n),
+        (api.tx as any)?.subtensorModule?.addStake?.(delegate, ROOT_NETUID, amount.decimalAmount?.planck ?? 0n),
         api.tx.system.remarkWithEvent(`talisman-bittensor`),
       ])
     }
@@ -135,11 +134,7 @@ export const useUnstakeForm = (stake: Stake, delegate: string) => {
       return (api.tx as any)?.subtensorModule?.removeStake?.(delegate, amount.decimalAmount?.planck ?? 0n)
     } catch {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return (api.tx as any)?.subtensorModule?.removeStake?.(
-        delegate,
-        MAINNET_NETUID,
-        amount.decimalAmount?.planck ?? 0n
-      )
+      return (api.tx as any)?.subtensorModule?.removeStake?.(delegate, ROOT_NETUID, amount.decimalAmount?.planck ?? 0n)
     }
   }, [api.tx, delegate, amount.decimalAmount?.planck])
   const extrinsic = useExtrinsic(tx)


### PR DESCRIPTION
## Description

Support root net id for subnet staking.

### Technical 

Since changes are not in prod, a try catch block has been added to handle 'default' staking and the new subnet staking on root net with `netuid = 0`

### Balances fetching issue:

Could't find any docs on it, but FAFOing around I noticed the `getStakeInfoForColdkey` now expects an address str as arg when before it expected a address vector.

For anyone interested in checking themselves:

- Go to polkadot js on [bittensor testnet runtime calls](https://polkadot.js.org/apps/?rpc=wss://test.chain.opentensor.ai:443#/runtime)
- Select `stakeInfoRuntimeApi` and `getStakeInfoForColdkey`


Note:

For reasons beyond my comprehension, it was simply not possible to call the exact same methods without vectorizing the address. It will throw.

Eg:
```const response = (await api.rpc.state.call('StakeInfoRuntimeApi_get_stake_info_for_coldkey', address))```
instead of
``` const response = (await api.rpc.state.call('StakeInfoRuntimeApi_get_stake_info_for_coldkey', params)).toHex()```

Throws

### 🖼️ **Screenshots:**
![Screenshot 2025-02-10 at 8 59 12](https://github.com/user-attachments/assets/105f91f7-aad5-4b76-82ce-d4ee3cd2a04d)

