### PR TITLE
fix: balance never loads in swaps for `S` on sonic

### DIFF
--- a/apps/portal/src/hooks/useFastBalance.ts
+++ b/apps/portal/src/hooks/useFastBalance.ts
@@ -1,6 +1,7 @@
-import { useMemo } from 'react'
-import { zeroAddress } from 'viem'
-import { useBalance } from 'wagmi'
+import { useEffect, useMemo, useState } from 'react'
+import { createPublicClient, erc20Abi, http, zeroAddress } from 'viem'
+import * as allEvmChains from 'viem/chains'
+import { type Chain as ViemChain } from 'viem/chains'
 
 import { Decimal } from '@/util/Decimal'
 
@@ -21,38 +22,86 @@ export const useFastBalance = (props?: UseFastBalanceProps) => {
     useMemo(() => (props?.type === 'substrate' ? props : undefined), [props])
   )
 
-  const evmBalance = useBalance(
-    props?.type === 'evm'
-      ? {
-          address: props.address,
-          chainId: props.networkId,
-          token: props.tokenAddress === zeroAddress ? undefined : props.tokenAddress,
-          query: {
-            refetchInterval: 12000,
-          },
-        }
-      : undefined
-  )
+  const evmBalance = useEvmBalance(props)
 
   return useMemo(() => {
     if (!props) return undefined
-    if (props.type === 'substrate') {
-      return {
-        ...props,
-        balance: substrateBalance,
+    if (props.type === 'substrate') return { ...props, balance: substrateBalance }
+    if (props.type === 'evm')
+      return { ...props, balance: evmBalance ? { transferrable: evmBalance, stayAlive: evmBalance } : undefined }
+    return undefined
+  }, [evmBalance, props, substrateBalance])
+}
+
+const useEvmBalance = (props?: UseFastBalanceProps) => {
+  const [evmBalance, setEvmBalance] = useState<Decimal | undefined>()
+
+  useEffect(() => {
+    const abortController = new AbortController()
+
+    if (props?.type !== 'evm') return setEvmBalance(undefined)
+
+    const chain: ViemChain | undefined = Object.values(allEvmChains).find(chain => chain.id === props.networkId)
+    const rpcUrl = chain?.rpcUrls.default.http[0]
+    if (!rpcUrl || !chain) return setEvmBalance(undefined)
+
+    const client = createPublicClient({ transport: http(rpcUrl), chain, batch: { multicall: true } })
+
+    const refetch = () => {
+      // native token
+      if (!props.tokenAddress || props.tokenAddress === zeroAddress) {
+        setEvmBalance(undefined)
+        client.getBalance({ address: props.address }).then(balance => {
+          if (abortController.signal.aborted) return
+
+          setEvmBalance(
+            Decimal.fromPlanck(balance, chain.nativeCurrency.decimals, { currency: chain.nativeCurrency.symbol })
+          )
+        })
       }
+
+      // erc20 token
+      client
+        .multicall({
+          contracts: [
+            {
+              abi: erc20Abi,
+              functionName: 'balanceOf',
+              address: props.tokenAddress!,
+              args: [props.address],
+            },
+            {
+              abi: erc20Abi,
+              functionName: 'symbol',
+              address: props.tokenAddress!,
+            },
+            {
+              abi: erc20Abi,
+              functionName: 'decimals',
+              address: props.tokenAddress!,
+            },
+          ],
+        })
+        .then(calls => {
+          if (abortController.signal.aborted) return
+
+          const [balanceCall, symbolCall, decimalsCall] = calls
+
+          const symbol = symbolCall.status === 'success' ? symbolCall.result : 'Unknown'
+          const decimals = decimalsCall.status === 'success' ? decimalsCall.result : 18
+
+          if (balanceCall.status === 'failure') return setEvmBalance(undefined)
+          setEvmBalance(Decimal.fromPlanck(balanceCall.result as bigint, decimals, { currency: symbol }))
+        })
     }
-    const ethBalance = evmBalance.data
-      ? Decimal.fromPlanck(evmBalance.data.value, evmBalance.data.decimals, { currency: evmBalance.data.symbol })
-      : undefined
-    return {
-      ...props,
-      balance: ethBalance
-        ? {
-            transferrable: ethBalance,
-            stayAlive: ethBalance,
-          }
-        : undefined,
-    }
-  }, [evmBalance.data, props, substrateBalance])
+
+    const intervalId = setInterval(refetch, 12_000)
+    abortController.signal.addEventListener = () => clearInterval(intervalId)
+
+    refetch()
+
+    return () => abortController.abort()
+  }, [props])
+
+  return evmBalance
 }


### PR DESCRIPTION
Switched from wagmi to viem for useFastBalance, so that if the balance is able to load in the token picker, there's a better chance it will also load after the token has been selected.