### PR TITLE
Fix/tao rootnet unstake fees

### DIFF
--- a/apps/portal/src/components/recipes/AddStakeDialog.tsx
+++ b/apps/portal/src/components/recipes/AddStakeDialog.tsx
@@ -2,8 +2,10 @@ import type { ReactNode } from 'react'
 import { Button } from '@talismn/ui/atoms/Button'
 import { CircularProgressIndicator } from '@talismn/ui/atoms/CircularProgressIndicator'
 import { Text } from '@talismn/ui/atoms/Text'
+import { Tooltip } from '@talismn/ui/atoms/Tooltip'
 import { AlertDialog } from '@talismn/ui/molecules/AlertDialog'
 import { TextInput } from '@talismn/ui/molecules/TextInput'
+import { Info } from '@talismn/web-icons'
 import { Suspense } from 'react'
 
 import { type TokenAmountFromPlank } from '@/domains/common/hooks/useTokenAmount'
@@ -65,12 +67,22 @@ const AddStakeForm = (props: AddStakeFormProps) => (
       </div>
     </div>
     {props.talismanFeeTokenAmount && (
-      <div className="mt-[0.5rem] flex items-center justify-between">
-        <Text.Body as="p" alpha="high">
-          {TALISMAN_FEE_BITTENSOR}% Talisman Fee
-        </Text.Body>
+      <div className="mt-[2rem] flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Text.Body as="p" alpha="high">
+            Talisman Fee
+          </Text.Body>
+          <Tooltip
+            content={
+              <div className="max-w-[35rem]">Talisman applies a {TALISMAN_FEE_BITTENSOR}% fee to each transaction.</div>
+            }
+            placement="top"
+          >
+            <Info size={16} />
+          </Tooltip>
+        </div>
         <Suspense fallback={<CircularProgressIndicator size="1em" />}>
-          <Text.Body alpha="high">{props.talismanFeeTokenAmount.decimalAmount?.toLocaleStringPrecision()}</Text.Body>
+          <Text.Body alpha="high">{props.talismanFeeTokenAmount?.decimalAmount?.toLocaleStringPrecision()}</Text.Body>
         </Suspense>
       </div>
     )}

--- a/apps/portal/src/components/recipes/AddStakeDialog.tsx
+++ b/apps/portal/src/components/recipes/AddStakeDialog.tsx
@@ -70,7 +70,7 @@ const AddStakeForm = (props: AddStakeFormProps) => (
       <div className="mt-[2rem] flex items-center justify-between">
         <div className="flex items-center gap-2">
           <Text.Body as="p" alpha="high">
-            Talisman Fee
+            Talisman fee
           </Text.Body>
           <Tooltip
             content={

--- a/apps/portal/src/components/recipes/UnstakeDialog.tsx
+++ b/apps/portal/src/components/recipes/UnstakeDialog.tsx
@@ -2,8 +2,10 @@ import type { ReactNode } from 'react'
 import { Button } from '@talismn/ui/atoms/Button'
 import { CircularProgressIndicator } from '@talismn/ui/atoms/CircularProgressIndicator'
 import { Text } from '@talismn/ui/atoms/Text'
+import { Tooltip } from '@talismn/ui/atoms/Tooltip'
 import { AlertDialog } from '@talismn/ui/molecules/AlertDialog'
 import { TextInput } from '@talismn/ui/molecules/TextInput'
+import { Info } from '@talismn/web-icons'
 import { Suspense } from 'react'
 
 import { type TokenAmountFromPlank } from '@/domains/common/hooks/useTokenAmount'
@@ -88,13 +90,25 @@ export const UnstakeDialog = (props: UnstakeDialogProps) => (
           </div>
         )}
         {props.talismanFeeTokenAmount && (
-          <div className="mt-[0.5rem] flex items-center justify-between">
-            <Text.Body as="p" alpha="high">
-              {TALISMAN_FEE_BITTENSOR}% Talisman Fee
-            </Text.Body>
+          <div className="mt-[2rem] flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Text.Body as="p" alpha="high">
+                Talisman Fee
+              </Text.Body>
+              <Tooltip
+                content={
+                  <div className="max-w-[35rem]">
+                    Talisman applies a {TALISMAN_FEE_BITTENSOR}% fee to each transaction.
+                  </div>
+                }
+                placement="top"
+              >
+                <Info size={16} />
+              </Tooltip>
+            </div>
             <Suspense fallback={<CircularProgressIndicator size="1em" />}>
               <Text.Body alpha="high">
-                {props.talismanFeeTokenAmount.decimalAmount?.toLocaleStringPrecision()}
+                {props.talismanFeeTokenAmount?.decimalAmount?.toLocaleStringPrecision()}
               </Text.Body>
             </Suspense>
           </div>

--- a/apps/portal/src/components/recipes/UnstakeDialog.tsx
+++ b/apps/portal/src/components/recipes/UnstakeDialog.tsx
@@ -93,7 +93,7 @@ export const UnstakeDialog = (props: UnstakeDialogProps) => (
           <div className="mt-[2rem] flex items-center justify-between">
             <div className="flex items-center gap-2">
               <Text.Body as="p" alpha="high">
-                Talisman Fee
+                Talisman fee
               </Text.Body>
               <Tooltip
                 content={

--- a/apps/portal/src/components/widgets/staking/subtensor/StakeItemRow.tsx
+++ b/apps/portal/src/components/widgets/staking/subtensor/StakeItemRow.tsx
@@ -31,6 +31,7 @@ export const StakeItemRow = ({
     amount: stake.totalStaked,
     netuid: stake.netuid,
     direction: 'alphaToTao',
+    shouldUpdateFeeAndSlippage: false,
   })
 
   const fiatBalance =

--- a/apps/portal/src/components/widgets/staking/subtensor/SubtensorStakingForm.tsx
+++ b/apps/portal/src/components/widgets/staking/subtensor/SubtensorStakingForm.tsx
@@ -228,7 +228,7 @@ export const SubtensorStakingSideSheet = ({
           <div className="mt-[2rem] flex items-center justify-between">
             <div className="flex items-center gap-2">
               <Text.Body as="p" alpha="high">
-                Talisman Fee
+                Talisman fee
               </Text.Body>
               <Tooltip
                 content={

--- a/apps/portal/src/domains/staking/subtensor/hooks/useGetDynamicTaoStakeInfo.ts
+++ b/apps/portal/src/domains/staking/subtensor/hooks/useGetDynamicTaoStakeInfo.ts
@@ -88,7 +88,6 @@ export const useGetDynamicTaoStakeInfo = ({
     if (direction === 'taoToAlpha' || netuid === ROOT_NETUID) {
       setTalismanTokenFee(taoToAlphaTalismanFeeFormatted)
     } else {
-      console.log("Something's wrong")
       setTalismanTokenFee(alphaToTaoTalismanFeeFormatted)
     }
   }, [

--- a/apps/portal/src/domains/staking/subtensor/hooks/useGetDynamicTaoStakeInfo.ts
+++ b/apps/portal/src/domains/staking/subtensor/hooks/useGetDynamicTaoStakeInfo.ts
@@ -1,7 +1,7 @@
 import { useAtomValue, useSetAtom } from 'jotai'
 import { useEffect } from 'react'
 
-import { TALISMAN_FEE_BITTENSOR } from '@/components/widgets/staking/subtensor/constants'
+import { ROOT_NETUID, TALISMAN_FEE_BITTENSOR } from '@/components/widgets/staking/subtensor/constants'
 import { useTokenAmount, useTokenAmountFromPlanck } from '@/domains/common/hooks/useTokenAmount'
 import { Decimal } from '@/util/Decimal'
 
@@ -22,10 +22,12 @@ export const useGetDynamicTaoStakeInfo = ({
   amount,
   netuid,
   direction,
+  shouldUpdateFeeAndSlippage,
 }: {
   amount: Amount
   netuid: number
   direction: Direction
+  shouldUpdateFeeAndSlippage: boolean
 }) => {
   const { data, isLoading, error } = useGetSubnetMetagraphByNetuid({ netuid })
   const setBittensorSlippage = useSetAtom(bittensorSlippageAtom)
@@ -76,12 +78,28 @@ export const useGetDynamicTaoStakeInfo = ({
   const alphaToTaoTalismanFeeFormatted = useTokenAmountFromPlanck(alphaToTaoTalismanFee)
 
   useEffect(() => {
+    if (!shouldUpdateFeeAndSlippage) return
     setBittensorSlippage(direction === 'taoToAlpha' ? slippage : alphaToTaoSlippage)
-  }, [alphaToTaoSlippage, direction, setBittensorSlippage, slippage])
+  }, [alphaToTaoSlippage, direction, setBittensorSlippage, shouldUpdateFeeAndSlippage, slippage])
 
   useEffect(() => {
-    setTalismanTokenFee(direction === 'taoToAlpha' ? taoToAlphaTalismanFeeFormatted : alphaToTaoTalismanFeeFormatted)
-  }, [alphaToTaoTalismanFeeFormatted, direction, setTalismanTokenFee, taoToAlphaTalismanFeeFormatted])
+    if (!shouldUpdateFeeAndSlippage) return
+    // Rootnet txs should use the taoToAlpha fee calculations
+    if (direction === 'taoToAlpha' || netuid === ROOT_NETUID) {
+      setTalismanTokenFee(taoToAlphaTalismanFeeFormatted)
+    } else {
+      console.log("Something's wrong")
+      setTalismanTokenFee(alphaToTaoTalismanFeeFormatted)
+    }
+  }, [
+    alphaToTaoTalismanFeeFormatted,
+    direction,
+    netuid,
+    setTalismanTokenFee,
+    shouldUpdateFeeAndSlippage,
+    taoToAlphaTalismanFee,
+    taoToAlphaTalismanFeeFormatted,
+  ])
 
   return {
     slippage,


### PR DESCRIPTION
# Description

- Fix rootnet unstake fees calculation and display.
- Refactor talisman fee ui on add/remove stake modals.

## Technical

Rootnet unstake txns were not applying fees. The fix is rootnet txs should use the taoToAlpha fee calculations.

### 🖼️ **Screenshots:**

![Screenshot 2025-02-18 at 10 52 29](https://github.com/user-attachments/assets/3b69e746-b5a7-4a1e-8704-e72d3311edc8)
![Screenshot 2025-02-18 at 10 53 01](https://github.com/user-attachments/assets/8ac87cf8-006d-4381-a41d-3284f1af4944)
