### PR TITLE
feat: r&d zap between subnets

### DIFF
--- a/apps/portal/src/components/recipes/StakePosition.tsx
+++ b/apps/portal/src/components/recipes/StakePosition.tsx
@@ -45,6 +45,7 @@ export type StakePositionProps = {
   unstakingStatus?: ReactNode
   increaseStakeButton?: ReactNode
   unstakeButton?: ReactNode
+  zapButton?: ReactNode
   lockedButton?: ReactNode
   menuButton?: ReactNode
   claimButton?: ReactNode
@@ -70,6 +71,15 @@ const UnstakeButton = (props: Omit<MenuItemProps, 'children'>) => (
     {({ readonly }) => (
       <Tooltip content="Account is readonly" disabled={!readonly}>
         <Menu.Item.Button headlineContent="Unstake" disabled={readonly} {...props} />
+      </Tooltip>
+    )}
+  </StakePositionContext.Consumer>
+)
+const ZapButton = (props: Omit<MenuItemProps, 'children'>) => (
+  <StakePositionContext.Consumer>
+    {({ readonly }) => (
+      <Tooltip content="Account is readonly" disabled={!readonly}>
+        <Menu.Item.Button headlineContent="Zap" disabled={readonly} {...props} />
       </Tooltip>
     )}
   </StakePositionContext.Consumer>
@@ -186,7 +196,7 @@ export const FastUnstakingStatus = (props: { amount: ReactNode; status: 'in-head
 
 export const StakePosition = Object.assign(
   (props: StakePositionProps) => {
-    const shouldRenderMenuBtn = props.unstakeButton || props.lockedButton || props.menuButton
+    const shouldRenderMenuBtn = props.unstakeButton || props.lockedButton || props.menuButton || props.zapButton
     const shouldRenderTotalRewards = props.rewards || props.fiatRewards
 
     return (
@@ -267,6 +277,7 @@ export const StakePosition = Object.assign(
                         <>
                           {props.unstakeButton}
                           {props.lockedButton}
+                          {props.zapButton}
                         </>
                       ),
                     }}
@@ -363,6 +374,7 @@ export const StakePosition = Object.assign(
   {
     IncreaseStakeButton,
     UnstakeButton,
+    ZapButton,
     MenuButton,
     ClaimButton,
     WithdrawButton,

--- a/apps/portal/src/components/widgets/staking/subtensor/StakeItemRow.tsx
+++ b/apps/portal/src/components/widgets/staking/subtensor/StakeItemRow.tsx
@@ -15,6 +15,7 @@ type StakeItemRowProps = {
   chain: ChainInfo
   handleToggleAddStakeDialog: (stakeItem?: StakeItem | undefined) => void
   handleToggleUnstakeDialog: (stakeItem?: StakeItem | undefined) => void
+  handleToggleZapDialog: (stakeItem?: StakeItem | undefined) => void
 }
 
 export const StakeItemRow = ({
@@ -23,6 +24,7 @@ export const StakeItemRow = ({
   chain,
   handleToggleAddStakeDialog,
   handleToggleUnstakeDialog,
+  handleToggleZapDialog,
 }: StakeItemRowProps) => {
   const { combinedValidatorsData } = useCombinedBittensorValidatorsData()
   const { expectedTaoAmount } = useGetDynamicTaoStakeInfo({
@@ -70,6 +72,11 @@ export const StakeItemRow = ({
         unstakeButton={
           <ErrorBoundary renderFallback={() => <>--</>}>
             <StakePosition.UnstakeButton onClick={() => handleToggleUnstakeDialog(stake)} withTransition />
+          </ErrorBoundary>
+        }
+        zapButton={
+          <ErrorBoundary renderFallback={() => <>--</>}>
+            <StakePosition.ZapButton onClick={() => handleToggleZapDialog(stake)} withTransition />
           </ErrorBoundary>
         }
       />

--- a/apps/portal/src/components/widgets/staking/subtensor/Stakes.tsx
+++ b/apps/portal/src/components/widgets/staking/subtensor/Stakes.tsx
@@ -12,6 +12,7 @@ import { useStake } from '@/domains/staking/subtensor/hooks/useStake'
 import AddStakeDialog from './AddStakeDialog'
 import { StakeItemRow } from './StakeItemRow'
 import UnstakeDialog from './UnstakeDialog'
+import { ZapDialog } from './ZapDialog'
 
 type StakesProps = {
   setShouldRenderLoadingSkeleton: React.Dispatch<React.SetStateAction<boolean>>
@@ -41,6 +42,7 @@ type StakeProps = {
 const Stake = ({ account, setShouldRenderLoadingSkeleton }: StakeProps) => {
   const [addStakeDialogOpen, setAddStakeDialogOpen] = useState<boolean>(false)
   const [unstakeDialogOpen, setUnstakeDialogOpen] = useState<boolean>(false)
+  const [zapDialogOpen, setZapDialogOpen] = useState<boolean>(false)
   const [selectedStake, setSelectedStake] = useState<StakeItem | undefined>()
 
   const chain = useRecoilValue(useChainState())
@@ -57,7 +59,13 @@ const Stake = ({ account, setShouldRenderLoadingSkeleton }: StakeProps) => {
   }
 
   const handleToggleUnstakeDialog = (stakeItem?: StakeItem | undefined) => {
+    console.log('called handle unstake')
     setUnstakeDialogOpen(prev => !prev)
+    setSelectedStake(stakeItem)
+  }
+  const handleToggleZapDialog = (stakeItem?: StakeItem | undefined) => {
+    console.log('Called handleZap')
+    setZapDialogOpen(prev => !prev)
     setSelectedStake(stakeItem)
   }
 
@@ -74,6 +82,7 @@ const Stake = ({ account, setShouldRenderLoadingSkeleton }: StakeProps) => {
             chain={chain}
             handleToggleAddStakeDialog={handleToggleAddStakeDialog}
             handleToggleUnstakeDialog={handleToggleUnstakeDialog}
+            handleToggleZapDialog={handleToggleZapDialog}
           />
         )
       })}
@@ -82,6 +91,14 @@ const Stake = ({ account, setShouldRenderLoadingSkeleton }: StakeProps) => {
       )}
       {unstakeDialogOpen && selectedStake && (
         <UnstakeDialog account={account} stake={selectedStake} onRequestDismiss={() => handleToggleUnstakeDialog()} />
+      )}
+      {zapDialogOpen && selectedStake && (
+        <ZapDialog
+          account={account}
+          stake={selectedStake}
+          onRequestDismiss={() => handleToggleZapDialog()}
+          isOpen={zapDialogOpen}
+        />
       )}
     </>
   )

--- a/apps/portal/src/components/widgets/staking/subtensor/ZapDialog.tsx
+++ b/apps/portal/src/components/widgets/staking/subtensor/ZapDialog.tsx
@@ -1,0 +1,142 @@
+import { Button } from '@talismn/ui/atoms/Button'
+import { Text } from '@talismn/ui/atoms/Text'
+import { AlertDialog } from '@talismn/ui/molecules/AlertDialog'
+import { ListItem } from '@talismn/ui/molecules/ListItem'
+import { Select } from '@talismn/ui/molecules/Select'
+import { TextInput } from '@talismn/ui/molecules/TextInput'
+import { useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { useRecoilValue } from 'recoil'
+
+import type { Account } from '@/domains/accounts/recoils'
+import { writeableSubstrateAccountsState } from '@/domains/accounts/recoils'
+import { useZapForm } from '@/domains/staking/subtensor/hooks/forms'
+import { type StakeItem } from '@/domains/staking/subtensor/hooks/useStake'
+import { type SubnetData } from '@/domains/staking/subtensor/types'
+
+import { useAccountSelector } from '../../AccountSelector'
+import { SubnetSelectorDialog } from './SubnetSelectorDialog'
+
+export type ZapDialogProps = {
+  account: Account
+  stake: StakeItem
+  onRequestDismiss: () => void
+  isOpen: boolean
+}
+
+export const ZapDialog = ({ stake, isOpen, onRequestDismiss }: ZapDialogProps) => {
+  const [subnet, setSubnet] = useState<SubnetData | undefined>()
+  const [subnetSelectorOpen, setSubnetSelectorOpen] = useState<boolean>(false)
+  const [searchParams] = useSearchParams()
+  const [[account]] = useAccountSelector(
+    useRecoilValue(writeableSubstrateAccountsState),
+    searchParams.get('account') === null
+      ? 0
+      : accounts => accounts?.find(x => x.address === searchParams.get('account'))
+  )
+
+  const queryClient = useQueryClient()
+
+  const handleStakeInfoRefetch = () => {
+    queryClient.invalidateQueries({ queryKey: ['stakeInfoForColdKey', account?.address] })
+  }
+
+  const { extrinsic, available, input, setInput, resultingZap, expectedAlphaAmount } = useZapForm(
+    stake,
+    stake.hotkey,
+    account,
+    subnet?.netuid ? Number(subnet.netuid) : 0
+  )
+
+  const onConfirm = () => {
+    if (!account) {
+      console.log('No account')
+      return
+    }
+    void extrinsic.signAndSend(account.address).then(() => {
+      handleStakeInfoRefetch()
+      onRequestDismiss()
+    })
+  }
+
+  const subnetName = subnet ? `${subnet?.netuid}: ${subnet.descriptionName} ${subnet?.symbol}` : undefined
+
+  return (
+    <>
+      <AlertDialog
+        open={isOpen}
+        title="Zap dTao"
+        targetWidth="44rem"
+        content={
+          <>
+            <Text.Body as="p" css={{ marginBottom: '2.6rem' }}>
+              How much would you like Zap?
+            </Text.Body>
+            <TextInput
+              type="number"
+              inputMode="decimal"
+              min={0}
+              step="any"
+              // isError={props.isError}
+              placeholder="0.00"
+              leadingLabel="Available to Zap"
+              trailingLabel={available?.decimalAmount?.toLocaleString() || `0 ${stake.symbol}`}
+              // leadingSupportingText={props.fiatAmount}
+              // trailingSupportingText={props.inputSupportingText}
+              trailingIcon={
+                <TextInput.LabelButton onClick={() => setInput(available?.decimalAmount?.toString() || '0')}>
+                  Max
+                </TextInput.LabelButton>
+              }
+              value={input}
+              onChange={event => setInput(event.target.value)}
+              css={{ fontSize: '3rem' }}
+            />
+
+            <div onClick={() => setSubnetSelectorOpen(true)}>
+              <label css={{ pointerEvents: 'none' }}>
+                <Text.BodySmall as="div" css={{ marginBottom: '0.8rem' }}>
+                  Select Subnet
+                </Text.BodySmall>
+                <Select
+                  placeholder={
+                    <ListItem headlineContent="Select a subnet" css={{ padding: '0.8rem', paddingLeft: 0 }} />
+                  }
+                  renderSelected={() => (
+                    <ListItem
+                      headlineContent={subnet ? subnetName : 'Select subnet'}
+                      css={{ padding: '0.8rem', paddingLeft: 0 }}
+                    />
+                  )}
+                  css={{ width: '100%' }}
+                />
+              </label>
+            </div>
+
+            <TextInput
+              type="number"
+              disabled
+              leadingLabel={subnet ? `Expected ${subnet.netuid} | ${subnet.symbol}` : 'Expected dTao'}
+              value={expectedAlphaAmount.decimalAmount?.toString()}
+              // value={resultingZap.decimalAmount.toLocaleString() || '0'}
+            />
+            {/* {props.expectedTokenAmount && props.expectedTokenAmount} */}
+            {/* <div css={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '1.6rem' }}>
+            <Text.Body alpha="high">New staked total</Text.Body>
+          </div> */}
+          </>
+        }
+        confirmButton={<Button onClick={onConfirm}>Zap</Button>}
+        onRequestDismiss={onRequestDismiss}
+      />
+      {subnetSelectorOpen && (
+        <SubnetSelectorDialog
+          selected={subnet}
+          onRequestDismiss={() => setSubnetSelectorOpen(false)}
+          onConfirm={setSubnet}
+        />
+      )}
+    </>
+  )
+}


### PR DESCRIPTION
# Description

RnD.

This PR proposes 'zapping' between staked subnets, for users who wants to move their position from subnet X to Y. Uses the unstaked dTao balance converted to Tao for a new stake action.

- Reduces fee charing, user pays fee only once.
- Reduces cognitive load, user does the "Zapping" in the same modal.
- User signs only one transaction.


Note: 

Either all txns fail or all succeed.

### Technical

Create a new `useZapForm` which batches remove_stake and add_stake limit. Slippage is taken into account when zapping.

### 🖼️ **Screenshots:**


https://github.com/user-attachments/assets/f787440b-c69b-4dd2-8a0a-2437acb2f3e0

