### PR TITLE
feat: store combined data in state, return if api call fails

### DIFF
--- a/apps/portal/src/domains/staking/subtensor/hooks/useCombineSubnetData.ts
+++ b/apps/portal/src/domains/staking/subtensor/hooks/useCombineSubnetData.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { type SubnetData } from '../types'
 import { useGetInfiniteSubnetDescriptions } from './useGetInfiniteSubnetDescriptions'

--- a/apps/portal/src/domains/staking/subtensor/hooks/useCombineSubnetData.ts
+++ b/apps/portal/src/domains/staking/subtensor/hooks/useCombineSubnetData.ts
@@ -48,8 +48,6 @@ export const useCombineSubnetData = () => {
       return acc
     }, {} as Record<number, SubnetData>)
 
-    console.log({ subnetDescriptionsData, subnetPoolsData, combinedSubnetData })
-
     setSubnetData(combinedSubnetData)
   }, [subnetDescriptionsData, subnetDescriptionsData?.pages, subnetPoolsData, subnetPoolsData?.pages])
 

--- a/apps/portal/src/domains/staking/subtensor/hooks/useCombinedBittensorValidatorsData.ts
+++ b/apps/portal/src/domains/staking/subtensor/hooks/useCombinedBittensorValidatorsData.ts
@@ -1,10 +1,11 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import { BondOption } from '../types'
 import { useGetBittensorInfiniteValidators } from './useGetBittensorInfiniteValidators'
 import { useGetBittensorSupportedDelegates } from './useGetBittensorSupportedDelegates'
 
 export const useCombinedBittensorValidatorsData = () => {
+  const [combinedValidatorsData, setCombinedValidatorsData] = useState<BondOption[]>([])
   const {
     data: supportedDelegates,
     isLoading: isSupportedDelegatesLoading,
@@ -25,7 +26,7 @@ export const useCombinedBittensorValidatorsData = () => {
     }
   }, [fetchNextPage, hasNextPage, isFetchingNextPage])
 
-  const combinedValidatorsData = useMemo(() => {
+  useEffect(() => {
     if (
       isSupportedDelegatesLoading ||
       isFetchingNextPage ||
@@ -33,7 +34,7 @@ export const useCombinedBittensorValidatorsData = () => {
       !supportedDelegates ||
       !infiniteValidators
     )
-      return []
+      return
 
     const flatInitialValidators = infiniteValidators.pages.flatMap(page => page.data)
 
@@ -51,8 +52,11 @@ export const useCombinedBittensorValidatorsData = () => {
       }
     })
 
-    return combined
+    if (combined.length === 0) return
+
+    setCombinedValidatorsData(combinedValidatorsData)
   }, [
+    combinedValidatorsData,
     infiniteValidators,
     isFetchingNextPage,
     isInfiniteValidatorsError,

--- a/apps/portal/src/domains/staking/subtensor/hooks/useCombinedBittensorValidatorsData.ts
+++ b/apps/portal/src/domains/staking/subtensor/hooks/useCombinedBittensorValidatorsData.ts
@@ -1,11 +1,10 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo } from 'react'
 
 import { BondOption } from '../types'
 import { useGetBittensorInfiniteValidators } from './useGetBittensorInfiniteValidators'
 import { useGetBittensorSupportedDelegates } from './useGetBittensorSupportedDelegates'
 
 export const useCombinedBittensorValidatorsData = () => {
-  const [combinedValidatorsData, setCombinedValidatorsData] = useState<BondOption[]>([])
   const {
     data: supportedDelegates,
     isLoading: isSupportedDelegatesLoading,
@@ -26,7 +25,7 @@ export const useCombinedBittensorValidatorsData = () => {
     }
   }, [fetchNextPage, hasNextPage, isFetchingNextPage])
 
-  useEffect(() => {
+  const combinedValidatorsData = useMemo(() => {
     if (
       isSupportedDelegatesLoading ||
       isFetchingNextPage ||
@@ -34,7 +33,7 @@ export const useCombinedBittensorValidatorsData = () => {
       !supportedDelegates ||
       !infiniteValidators
     )
-      return
+      return []
 
     const flatInitialValidators = infiniteValidators.pages.flatMap(page => page.data)
 
@@ -52,11 +51,8 @@ export const useCombinedBittensorValidatorsData = () => {
       }
     })
 
-    if (combined.length === 0) return
-
-    setCombinedValidatorsData(combinedValidatorsData)
+    return combined
   }, [
-    combinedValidatorsData,
     infiniteValidators,
     isFetchingNextPage,
     isInfiniteValidatorsError,

--- a/apps/portal/src/domains/staking/subtensor/hooks/useCombinedBittensorValidatorsData.ts
+++ b/apps/portal/src/domains/staking/subtensor/hooks/useCombinedBittensorValidatorsData.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { BondOption } from '../types'
 import { useGetBittensorInfiniteValidators } from './useGetBittensorInfiniteValidators'


### PR DESCRIPTION
# Description

Store combined api response data in state, do not update state if api call fails.

## Technical

The API calls are being pre populated with placeholder data, which then gets hydrated with fresh data from api responses. The issue arises when the api response fail, and placeholder data then gets replaced by `null`