### PR TITLE
Feat/bittensor move stake

### DIFF
--- a/apps/portal/src/components/recipes/StakePosition.tsx
+++ b/apps/portal/src/components/recipes/StakePosition.tsx
@@ -40,6 +40,7 @@ export type StakePositionProps = {
   fiatRewards?: ReactNode
   unstakingStatus?: ReactNode
   increaseStakeButton?: ReactNode
+  changeValidatorButton?: ReactNode
   unstakeButton?: ReactNode
   lockedButton?: ReactNode
   menuButton?: ReactNode
@@ -66,6 +67,16 @@ const UnstakeButton = (props: Omit<MenuItemProps, 'children'>) => (
     {({ readonly }) => (
       <Tooltip content="Account is readonly" disabled={!readonly}>
         <Menu.Item.Button headlineContent="Unstake" disabled={readonly} {...props} />
+      </Tooltip>
+    )}
+  </StakePositionContext.Consumer>
+)
+
+const ChangeValidatorButton = (props: Omit<MenuItemProps, 'children'>) => (
+  <StakePositionContext.Consumer>
+    {({ readonly }) => (
+      <Tooltip content="Account is readonly" disabled={!readonly}>
+        <Menu.Item.Button headlineContent="Change Validator" disabled={readonly} {...props} />
       </Tooltip>
     )}
   </StakePositionContext.Consumer>
@@ -212,6 +223,7 @@ export const StakePosition = Object.assign(
                         <>
                           {props.unstakeButton}
                           {props.lockedButton}
+                          {props.changeValidatorButton}
                         </>
                       ),
                     }}
@@ -324,6 +336,7 @@ export const StakePosition = Object.assign(
   {
     IncreaseStakeButton,
     UnstakeButton,
+    ChangeValidatorButton,
     MenuButton,
     ClaimButton,
     WithdrawButton,

--- a/apps/portal/src/components/recipes/StakePosition.tsx
+++ b/apps/portal/src/components/recipes/StakePosition.tsx
@@ -26,6 +26,8 @@ import { StakePositionSkeleton } from './StakePosition.skeleton'
 
 export type StakePositionProps = {
   readonly?: boolean
+  isError?: boolean
+  errorMessage?: string | null
   account: Account
   provider: ReactNode
   shortProvider?: ReactNode
@@ -48,7 +50,7 @@ export type StakePositionProps = {
   withdrawButton?: ReactNode
 }
 
-const StakePositionContext = createContext({ readonly: false })
+const StakePositionContext = createContext({ readonly: false, isError: false, errorMessage: '' })
 
 const IncreaseStakeButton = (props: Omit<IconButtonProps, 'children'>) => (
   <StakePositionContext.Consumer>
@@ -74,11 +76,13 @@ const UnstakeButton = (props: Omit<MenuItemProps, 'children'>) => (
 
 const ChangeValidatorButton = (props: Omit<MenuItemProps, 'children'>) => (
   <StakePositionContext.Consumer>
-    {({ readonly }) => (
-      <Tooltip content="Account is readonly" disabled={!readonly}>
-        <Menu.Item.Button headlineContent="Change Validator" disabled={readonly} {...props} />
-      </Tooltip>
-    )}
+    {({ readonly, isError, errorMessage }) => {
+      return (
+        <Tooltip content={readonly ? 'Account is readonly' : errorMessage} disabled={!readonly && !isError}>
+          <Menu.Item.Button headlineContent="Change Validator" disabled={readonly || isError} {...props} />
+        </Tooltip>
+      )
+    }}
   </StakePositionContext.Consumer>
 )
 
@@ -197,7 +201,13 @@ export const StakePosition = Object.assign(
     const shouldRenderTotalRewards = props.rewards || props.fiatRewards
 
     return (
-      <StakePositionContext.Provider value={{ readonly: props.readonly ?? false }}>
+      <StakePositionContext.Provider
+        value={{
+          readonly: props.readonly ?? false,
+          isError: props.isError ?? false,
+          errorMessage: props.errorMessage ?? '',
+        }}
+      >
         <div className="@container">
           <Surface className="@[100rem]:flex-row @[100rem]:items-center flex flex-col gap-[0.8rem] rounded-[1.6rem] p-[1.6rem]">
             <div className="@[100rem]:contents flex items-center justify-between gap-[0.8rem]">

--- a/apps/portal/src/components/widgets/staking/subtensor/DelegateSelectorDialog.tsx
+++ b/apps/portal/src/components/widgets/staking/subtensor/DelegateSelectorDialog.tsx
@@ -14,6 +14,7 @@ type DelegateSelectorDialogProps = {
   selected?: BondOption
   onRequestDismiss: () => unknown
   onConfirm: (delegate: BondOption) => unknown
+  setHighlightedDelegate?: React.Dispatch<React.SetStateAction<BondOption | undefined>>
 }
 
 export const DelegateSelectorDialog = (props: DelegateSelectorDialogProps) => {
@@ -98,7 +99,10 @@ export const DelegateSelectorDialog = (props: DelegateSelectorDialogProps) => {
             count={!isError ? delegate.totalStakers : 0}
             balance={formattedBalance ?? ''}
             balancePlanck={balance.decimalAmount?.planck}
-            onClick={() => setHighlighted(delegate)}
+            onClick={() => {
+              setHighlighted(delegate)
+              props.setHighlightedDelegate?.(delegate)
+            }}
             className="min-h-[9.6rem]"
           />
         )

--- a/apps/portal/src/components/widgets/staking/subtensor/StakeItemRow.tsx
+++ b/apps/portal/src/components/widgets/staking/subtensor/StakeItemRow.tsx
@@ -15,6 +15,7 @@ type StakeItemRowProps = {
   chain: ChainInfo
   handleToggleAddStakeDialog: (stakeItem?: StakeItem | undefined) => void
   handleToggleUnstakeDialog: (stakeItem?: StakeItem | undefined) => void
+  handleToggleChangeValidator: (stakeItem?: StakeItem | undefined) => void
 }
 
 export const StakeItemRow = ({
@@ -23,6 +24,7 @@ export const StakeItemRow = ({
   chain,
   handleToggleAddStakeDialog,
   handleToggleUnstakeDialog,
+  handleToggleChangeValidator,
 }: StakeItemRowProps) => {
   const { combinedValidatorsData } = useCombinedBittensorValidatorsData()
   const { expectedTaoAmount } = useGetDynamicTaoStakeInfo({
@@ -70,6 +72,11 @@ export const StakeItemRow = ({
         unstakeButton={
           <ErrorBoundary renderFallback={() => <>--</>}>
             <StakePosition.UnstakeButton onClick={() => handleToggleUnstakeDialog(stake)} withTransition />
+          </ErrorBoundary>
+        }
+        changeValidatorButton={
+          <ErrorBoundary renderFallback={() => <>--</>}>
+            <StakePosition.ChangeValidatorButton onClick={() => handleToggleChangeValidator(stake)} withTransition />
           </ErrorBoundary>
         }
       />

--- a/apps/portal/src/components/widgets/staking/subtensor/StakeItemRow.tsx
+++ b/apps/portal/src/components/widgets/staking/subtensor/StakeItemRow.tsx
@@ -6,6 +6,8 @@ import { DTAO_LOGO, ROOT_NETUID } from '@/components/widgets/staking/subtensor/c
 import { ChainInfo } from '@/domains/chains/recoils'
 import { useCombinedBittensorValidatorsData } from '@/domains/staking/subtensor/hooks/useCombinedBittensorValidatorsData'
 import { useGetDynamicTaoStakeInfo } from '@/domains/staking/subtensor/hooks/useGetDynamicTaoStakeInfo'
+import { useMoveStake } from '@/domains/staking/subtensor/hooks/useMoveStake'
+import { type BondOption } from '@/domains/staking/subtensor/types'
 
 import ErrorBoundaryFallback from '../ErrorBoundaryFallback'
 
@@ -13,6 +15,7 @@ type StakeItemRowProps = {
   stake: StakeItem
   account: Account
   chain: ChainInfo
+  highlightedDelegate?: BondOption
   handleToggleAddStakeDialog: (stakeItem?: StakeItem | undefined) => void
   handleToggleUnstakeDialog: (stakeItem?: StakeItem | undefined) => void
   handleToggleChangeValidator: (stakeItem?: StakeItem | undefined) => void
@@ -22,6 +25,7 @@ export const StakeItemRow = ({
   stake,
   account,
   chain,
+  highlightedDelegate,
   handleToggleAddStakeDialog,
   handleToggleUnstakeDialog,
   handleToggleChangeValidator,
@@ -32,6 +36,11 @@ export const StakeItemRow = ({
     netuid: stake.netuid,
     direction: 'alphaToTao',
     shouldUpdateFeeAndSlippage: false,
+  })
+
+  const { isError, errorMessage } = useMoveStake({
+    stake,
+    destinationHotkey: highlightedDelegate?.poolId,
   })
 
   const { name = '', nativeToken: { symbol, logo } = { symbol: '', logo: '' } } = chain || {}
@@ -58,6 +67,8 @@ export const StakeItemRow = ({
         account={account}
         provider={provider}
         stakeStatus={'earning_rewards'}
+        isError={isError}
+        errorMessage={errorMessage}
         balance={
           <ErrorBoundary renderFallback={() => <>--</>}>
             {stake.totalStaked.decimalAmount?.toLocaleString()}

--- a/apps/portal/src/components/widgets/staking/subtensor/Stakes.tsx
+++ b/apps/portal/src/components/widgets/staking/subtensor/Stakes.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query'
 import { useCallback, useEffect, useState } from 'react'
 import { useRecoilValue } from 'recoil'
 
@@ -50,6 +51,8 @@ const Stake = ({ account, setShouldRenderLoadingSkeleton }: StakeProps) => {
   const [selectedDelegate, setSelectedDelegate] = useState<BondOption | undefined>()
   const [highlightedDelegate, setHighlightedDelegate] = useState<BondOption | undefined>()
 
+  const queryClient = useQueryClient()
+
   const { extrinsic, isReady } = useMoveStake({ stake: selectedStake, destinationHotkey: highlightedDelegate?.poolId })
 
   const { combinedValidatorsData } = useCombinedBittensorValidatorsData()
@@ -82,12 +85,14 @@ const Stake = ({ account, setShouldRenderLoadingSkeleton }: StakeProps) => {
     if (isReady)
       extrinsic
         .signAndSend(account.address)
-        .then(() => console.log('SUCCESS'))
+        .then(() => {
+          queryClient.invalidateQueries({ queryKey: ['stakeInfoForColdKey', account.address] })
+        })
         .finally(() => {
           setSelectedDelegate(undefined)
           setSelectedStake(undefined)
         })
-  }, [account.address, extrinsic, isReady])
+  }, [account.address, extrinsic, isReady, queryClient])
 
   if (stakes.length === 0) return null
 

--- a/apps/portal/src/components/widgets/staking/subtensor/Stakes.tsx
+++ b/apps/portal/src/components/widgets/staking/subtensor/Stakes.tsx
@@ -53,7 +53,10 @@ const Stake = ({ account, setShouldRenderLoadingSkeleton }: StakeProps) => {
 
   const queryClient = useQueryClient()
 
-  const { extrinsic, isReady } = useMoveStake({ stake: selectedStake, destinationHotkey: highlightedDelegate?.poolId })
+  const { extrinsic, isReady } = useMoveStake({
+    stake: selectedStake,
+    destinationHotkey: highlightedDelegate?.poolId,
+  })
 
   const { combinedValidatorsData } = useCombinedBittensorValidatorsData()
 
@@ -105,6 +108,7 @@ const Stake = ({ account, setShouldRenderLoadingSkeleton }: StakeProps) => {
             stake={stake}
             account={account}
             chain={chain}
+            highlightedDelegate={highlightedDelegate}
             handleToggleAddStakeDialog={handleToggleAddStakeDialog}
             handleToggleUnstakeDialog={handleToggleUnstakeDialog}
             handleToggleChangeValidator={handleToggleChangeValidator}

--- a/apps/portal/src/domains/staking/subtensor/hooks/useMoveStake.ts
+++ b/apps/portal/src/domains/staking/subtensor/hooks/useMoveStake.ts
@@ -2,8 +2,12 @@ import { type SubmittableExtrinsic } from '@polkadot/api/types'
 import { useMemo } from 'react'
 import { useRecoilValue } from 'recoil'
 
+import { MIN_SUBTENSOR_ROOTNET_STAKE, ROOT_NETUID } from '@/components/widgets/staking/subtensor/constants'
+import { useNativeTokenAmountState } from '@/domains/chains/recoils'
 import { useExtrinsic } from '@/domains/common/hooks/useExtrinsic'
 import { useSubstrateApiState } from '@/domains/common/hooks/useSubstrateApiState'
+import { useTokenAmount } from '@/domains/common/hooks/useTokenAmount'
+import { useGetDynamicTaoStakeInfo } from '@/domains/staking/subtensor/hooks/useGetDynamicTaoStakeInfo'
 
 import { type StakeItem } from './useStake'
 
@@ -14,7 +18,38 @@ type MoveItem = {
 
 export const useMoveStake = ({ stake, destinationHotkey }: MoveItem) => {
   const api = useRecoilValue(useSubstrateApiState())
-  const { hotkey: originHotkey, netuid: originNetuid, stake: alphaAmount } = stake || {}
+  const nativeTokenAmount = useRecoilValue(useNativeTokenAmountState())
+
+  const { hotkey: originHotkey, netuid: originNetuid, stake: alphaAmount, netuid, symbol } = stake || {}
+  const formattedAlphaAmount = nativeTokenAmount.fromPlanckOrUndefined(alphaAmount, symbol)
+
+  const { minAlphaUnstake } = useGetDynamicTaoStakeInfo({
+    amount: formattedAlphaAmount,
+    netuid: netuid ?? 0,
+    direction: 'alphaToTao',
+    shouldUpdateFeeAndSlippage: false,
+  })
+
+  const isRootnetStake = netuid === ROOT_NETUID
+  const minimum = useTokenAmount(String(isRootnetStake ? MIN_SUBTENSOR_ROOTNET_STAKE : minAlphaUnstake))
+  const minimumFormatted = nativeTokenAmount.fromPlanckOrUndefined(minimum.decimalAmount?.planck ?? 0n, stake?.symbol)
+
+  const { isError, errorMessage } = useMemo(() => {
+    const validations: Array<{ condition: boolean; message: string }> = [
+      {
+        condition: (formattedAlphaAmount.decimalAmount?.planck ?? 0n) < (minimumFormatted.decimalAmount?.planck ?? 0n),
+        message: `Minimum staked amount for changing validator is ${minimumFormatted.decimalAmount?.toLocaleStringPrecision()}`,
+      },
+    ]
+
+    const firstError = validations.find(v => v.condition)
+
+    return {
+      isError: Boolean(firstError),
+      errorMessage: firstError?.message ?? null,
+    }
+  }, [formattedAlphaAmount.decimalAmount, minimumFormatted.decimalAmount])
+
   const isReady = stake && destinationHotkey && originHotkey !== destinationHotkey
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -37,5 +72,5 @@ export const useMoveStake = ({ stake, destinationHotkey }: MoveItem) => {
 
   const extrinsic = useExtrinsic(tx)
 
-  return { extrinsic, isReady }
+  return { extrinsic, isReady, isError, errorMessage }
 }

--- a/apps/portal/src/domains/staking/subtensor/hooks/useMoveStake.ts
+++ b/apps/portal/src/domains/staking/subtensor/hooks/useMoveStake.ts
@@ -31,7 +31,7 @@ export const useMoveStake = ({ stake, destinationHotkey }: MoveItem) => {
         originNetuid, // destinationNetuid, in this case, is the same as originNetuid
         alphaAmount
       ),
-      api.tx.system.remarkWithEvent(`talisman-bittensor`),
+      api.tx.system.remarkWithEvent('talisman-bittensor'),
     ])
   }, [stake, destinationHotkey, api.tx, originHotkey, originNetuid, alphaAmount])
 

--- a/apps/portal/src/domains/staking/subtensor/hooks/useMoveStake.ts
+++ b/apps/portal/src/domains/staking/subtensor/hooks/useMoveStake.ts
@@ -1,0 +1,41 @@
+import { type SubmittableExtrinsic } from '@polkadot/api/types'
+import { useMemo } from 'react'
+import { useRecoilValue } from 'recoil'
+
+import { useExtrinsic } from '@/domains/common/hooks/useExtrinsic'
+import { useSubstrateApiState } from '@/domains/common/hooks/useSubstrateApiState'
+
+import { type StakeItem } from './useStake'
+
+type MoveItem = {
+  stake: StakeItem | undefined
+  destinationHotkey: string | undefined
+}
+
+export const useMoveStake = ({ stake, destinationHotkey }: MoveItem) => {
+  const api = useRecoilValue(useSubstrateApiState())
+  const { hotkey: originHotkey, netuid: originNetuid, stake: alphaAmount } = stake || {}
+  const isReady = stake && destinationHotkey && originHotkey !== destinationHotkey
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const tx: SubmittableExtrinsic<any> = useMemo(() => {
+    // Return null if stake or destinationHotkey is not defined
+    if (!stake || !destinationHotkey) return api.tx.system.remarkWithEvent('talisman-bittensor')
+
+    return api.tx.utility.batchAll([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (api.tx as any)?.subtensorModule?.moveStake?.(
+        originHotkey,
+        destinationHotkey,
+        originNetuid,
+        originNetuid, // destinationNetuid, in this case, is the same as originNetuid
+        alphaAmount
+      ),
+      api.tx.system.remarkWithEvent(`talisman-bittensor`),
+    ])
+  }, [stake, destinationHotkey, api.tx, originHotkey, originNetuid, alphaAmount])
+
+  const extrinsic = useExtrinsic(tx)
+
+  return { extrinsic, isReady }
+}


### PR DESCRIPTION
# Description

Enable users to switch staked position's validators without charging fees.

## Technical 

Create new `useMoveStake` hook to handle moving staked positions. Note: we should move `useAddStakeForm` and `useUnstakeForm` hooks that are currently in the form file, for better maintenance.

### 🖼️ **Screenshots:**


https://github.com/user-attachments/assets/489e33d1-912c-49fb-a0ca-d98be9a0b080



