### PR TITLE
fix: Add stake modal toggling open when changing validator

### DIFF
--- a/apps/portal/src/components/widgets/staking/subtensor/Stakes.tsx
+++ b/apps/portal/src/components/widgets/staking/subtensor/Stakes.tsx
@@ -116,7 +116,7 @@ const Stake = ({ account, setShouldRenderLoadingSkeleton }: StakeProps) => {
         )
       })}
       {addStakeDialogOpen && selectedStake && (
-        <AddStakeDialog account={account} stake={selectedStake} onRequestDismiss={() => handleToggleAddStakeDialog()} />
+        <AddStakeDialog account={account} stake={selectedStake} onRequestDismiss={() => setAddStakeDialogOpen(false)} />
       )}
       {unstakeDialogOpen && selectedStake && (
         <UnstakeDialog account={account} stake={selectedStake} onRequestDismiss={() => handleToggleUnstakeDialog()} />


### PR DESCRIPTION
# Description

Fixes increase stake modal being opening after extrinsic has been successfully included in the block by clicking on "change validator"

- `useExtrinsicInBlockOrErrorEffect` hook is alive in memory somewhere, and passing a function that toggles state will keep toggling it. The quick and easy solution is to pass a callback fn that set state to false. 