### PR TITLE
chore: default provider name to manage delegation

### DIFF
--- a/apps/portal/src/components/widgets/staking/subtensor/StakeItemRow.tsx
+++ b/apps/portal/src/components/widgets/staking/subtensor/StakeItemRow.tsx
@@ -46,7 +46,7 @@ export const StakeItemRow = ({
   const { name = '', nativeToken: { symbol, logo } = { symbol: '', logo: '' } } = chain || {}
   const assetSymbol = stake.netuid === ROOT_NETUID ? symbol : `SN${stake.netuid} ${stake.descriptionName ?? ''}`
   const assetLogo = stake.netuid === ROOT_NETUID ? logo : DTAO_LOGO
-  const provider = combinedValidatorsData.find(({ poolId }) => poolId === stake.hotkey)?.name ?? ''
+  const provider = combinedValidatorsData.find(({ poolId }) => poolId === stake.hotkey)?.name ?? 'Managed delegation'
 
   const fiatBalance =
     stake.netuid === ROOT_NETUID ? stake.totalStaked.localizedFiatAmount : expectedTaoAmount.localizedFiatAmount


### PR DESCRIPTION
# Description

Defaults to "Managed delegation" label when not staked with any known subnets known to taostats api

### 🧪 **How to test:**

Add the following watched account, it should display "Managed delegation" for their Mentat minds staked positions: 5Co21odW75rPN1btp9FEPEnPd4t7WJoSCUcsyvTbHVVnLAHp

