### PR TITLE
chore: updated toastats api endpoints

### DIFF
--- a/apps/portal/src/components/widgets/staking/subtensor/DelegateSelectorDialog.tsx
+++ b/apps/portal/src/components/widgets/staking/subtensor/DelegateSelectorDialog.tsx
@@ -27,7 +27,7 @@ export const DelegateSelectorDialog = (props: DelegateSelectorDialogProps) => {
   const [highlighted, setHighlighted] = useState<BondOption | undefined>()
   const nativeTokenAmount = useRecoilValue(useNativeTokenAmountState())
 
-  let sortMethods: {
+  const sortMethods: {
     [key: string]: (
       a: ReactElement<StakeTargetSelectorItemProps>,
       b: ReactElement<StakeTargetSelectorItemProps>
@@ -44,14 +44,15 @@ export const DelegateSelectorDialog = (props: DelegateSelectorDialogProps) => {
       parseInt(b.props.count?.toString?.() ?? '0') - parseInt(a.props.count?.toString?.() ?? '0'),
   }
 
-  if (!hasDTaoStaking) {
-    sortMethods = {
-      ...sortMethods,
-      'Estimated APR': (a, b) =>
-        parseFloat(b.props.estimatedApr?.replace('%', '') ?? '0') -
-        parseFloat(a.props.estimatedApr?.replace('%', '') ?? '0'),
-    }
-  }
+  // TODO: Uncomment this when taostats provide APR data, view useGetBittensorInfiniteValidators api endpoint
+  // if (!hasDTaoStaking) {
+  //   sortMethods = {
+  //     ...sortMethods,
+  //     'Estimated APR': (a, b) =>
+  //       parseFloat(b.props.estimatedApr?.replace('%', '') ?? '0') -
+  //       parseFloat(a.props.estimatedApr?.replace('%', '') ?? '0'),
+  //   }
+  // }
 
   return (
     <StakeTargetSelectorDialog
@@ -67,9 +68,11 @@ export const DelegateSelectorDialog = (props: DelegateSelectorDialogProps) => {
       isSortDisabled={isError}
     >
       {combinedValidatorsData.map(delegate => {
-        let formattedApr = !hasDTaoStaking
-          ? delegate.apr.toLocaleString(undefined, { style: 'percent', maximumFractionDigits: 2 })
-          : ''
+        let formattedApr = '--'
+        // TODO: Uncomment this when taostats provide APR data, view useGetBittensorInfiniteValidators api endpoint
+        // let formattedApr = !hasDTaoStaking
+        //   ? delegate.apr.toLocaleString(undefined, { style: 'percent', maximumFractionDigits: 2 })
+        //   : ''
 
         const balance = nativeTokenAmount.fromPlanckOrUndefined(delegate.totalStaked)
 
@@ -80,7 +83,7 @@ export const DelegateSelectorDialog = (props: DelegateSelectorDialogProps) => {
 
         if (isError) {
           formattedBalance = ''
-          formattedApr = ''
+          formattedApr = '--'
         }
 
         return (

--- a/apps/portal/src/components/widgets/staking/subtensor/StakeForm.tsx
+++ b/apps/portal/src/components/widgets/staking/subtensor/StakeForm.tsx
@@ -9,7 +9,7 @@ import { useRecoilValue } from 'recoil'
 import { Account } from '@/domains/accounts/recoils'
 import { useNativeTokenAmountState } from '@/domains/chains/recoils'
 import { useAddStakeForm } from '@/domains/staking/subtensor/hooks/forms'
-import { useDelegateApr } from '@/domains/staking/subtensor/hooks/useApr'
+// import { useDelegateApr } from '@/domains/staking/subtensor/hooks/useApr'
 import { useStake } from '@/domains/staking/subtensor/hooks/useStake'
 
 import { SubtensorStakingForm } from './SubtensorStakingForm'
@@ -125,7 +125,9 @@ export const IncompleteSelectionStakeForm = ({
 
 const EstimatedRewards = (props: { amount: bigint; delegateHotkey: string }) => {
   const tokenAmount = useRecoilValue(useNativeTokenAmountState())
-  const delegateApr = useDelegateApr(props.delegateHotkey) || 0
+  // TODO: Uncomment this when taostats provide APR data, view useGetBittensorInfiniteValidators api endpoint
+  // const delegateApr = useDelegateApr(props.delegateHotkey) || 0
+  const delegateApr = 0
   const amount = useMemo(
     () => tokenAmount.fromPlanck(new BN(props.amount.toString()).muln(delegateApr).toString()),
     [delegateApr, props.amount, tokenAmount]

--- a/apps/portal/src/domains/staking/subtensor/hooks/useApr.ts
+++ b/apps/portal/src/domains/staking/subtensor/hooks/useApr.ts
@@ -26,7 +26,7 @@ export const useHighestApr = () => {
   return Number(apr)
 }
 
-export const useDelegateApr = (hotkey: string | undefined) => {
+export const useDelegateApr = () => {
   // TODO: Uncomment this when taostats provide APR data, view useGetBittensorInfiniteValidators api endpoint
 
   // const { combinedValidatorsData } = useCombinedBittensorValidatorsData()

--- a/apps/portal/src/domains/staking/subtensor/hooks/useApr.ts
+++ b/apps/portal/src/domains/staking/subtensor/hooks/useApr.ts
@@ -1,4 +1,4 @@
-import { useCombinedBittensorValidatorsData } from './useCombinedBittensorValidatorsData'
+// import { useCombinedBittensorValidatorsData } from './useCombinedBittensorValidatorsData'
 
 export const useHighestAprFormatted = () => {
   const apr = useHighestApr()
@@ -7,22 +7,31 @@ export const useHighestAprFormatted = () => {
 }
 
 export const useHighestApr = () => {
-  const { combinedValidatorsData } = useCombinedBittensorValidatorsData()
-  type ValidatorData = {
-    apr: number
-  }
+  // TODO: Uncomment this when taostats provide APR data, view useGetBittensorInfiniteValidators api endpoint
 
-  const highestAprValidator: ValidatorData = combinedValidatorsData.reduce<ValidatorData>(
-    (acc: ValidatorData, curr: ValidatorData) => (curr.apr > acc.apr ? curr : acc),
-    { apr: 0 }
-  )
+  // const { combinedValidatorsData } = useCombinedBittensorValidatorsData()
+  // type ValidatorData = {
+  //   apr: number
+  // }
+
+  // const highestAprValidator: ValidatorData = combinedValidatorsData.reduce<ValidatorData>(
+  //   (acc: ValidatorData, curr: ValidatorData) => (curr.apr > acc.apr ? curr : acc),
+  //   { apr: 0 }
+  // )
+
+  const highestAprValidator = { apr: 0 }
+
   const { apr } = highestAprValidator ?? { apr: 0 }
 
   return Number(apr)
 }
 
 export const useDelegateApr = (hotkey: string | undefined) => {
-  const { combinedValidatorsData } = useCombinedBittensorValidatorsData()
-  const delegate = combinedValidatorsData.find(validator => validator?.poolId === hotkey)
-  return Number(delegate?.apr)
+  // TODO: Uncomment this when taostats provide APR data, view useGetBittensorInfiniteValidators api endpoint
+
+  // const { combinedValidatorsData } = useCombinedBittensorValidatorsData()
+  // const delegate = combinedValidatorsData.find(validator => validator?.poolId === hotkey)
+  // return Number(delegate?.apr)
+
+  return undefined
 }

--- a/apps/portal/src/domains/staking/subtensor/hooks/useCombinedBittensorValidatorsData.ts
+++ b/apps/portal/src/domains/staking/subtensor/hooks/useCombinedBittensorValidatorsData.ts
@@ -39,9 +39,8 @@ export const useCombinedBittensorValidatorsData = () => {
       return {
         poolId: key,
         name: supportedDelegate?.name ?? '',
-        apr: parseFloat(validator?.apr ?? '0'),
-        totalStaked: parseFloat(validator?.stake ?? '0'),
-        totalStakers: validator?.nominators ?? 0,
+        totalStaked: parseFloat(validator?.global_weighted_stake ?? '0'),
+        totalStakers: validator?.global_nominators ?? 0,
         hasData: !!validator,
         isError: isInfiniteValidatorsError,
       }

--- a/apps/portal/src/domains/staking/subtensor/hooks/useGetBittensorInfiniteValidators.ts
+++ b/apps/portal/src/domains/staking/subtensor/hooks/useGetBittensorInfiniteValidators.ts
@@ -10,7 +10,7 @@ const MAX_PAGE_SIZE = 100
 const fetchBittensorInfiniteValidators = async (page: number = 1): Promise<ValidatorsData> => {
   try {
     const response = await (
-      await fetch(`${TAOSTATS_API_URL}/api/validator/latest/v1?page=${page}&limit=${MAX_PAGE_SIZE}`, {
+      await fetch(`${TAOSTATS_API_URL}/api/dtao/validator/latest/v1?page=${page}&limit=${MAX_PAGE_SIZE}`, {
         method: 'GET',
         headers: {
           'X-Extension-ID': TAOSTATS_API_KEY ?? '',

--- a/apps/portal/src/domains/staking/subtensor/types.ts
+++ b/apps/portal/src/domains/staking/subtensor/types.ts
@@ -13,43 +13,30 @@ type Key = {
   hex: string
 }
 
-// Subnet Dominance Type
-type SubnetDominance = {
-  netuid: number
-  dominance: string
-  family_stake: string
-}
-
 // Validator Data Type
 type ValidatorData = {
   hotkey: Key
   coldkey: Key
   name: string
   block_number: number
-  timestamp: string // ISO date format string
+  timestamp: string
+  created_on_date: string
   rank: number
-  nominators: number
-  nominators_24_hr_change: number
-  system_stake: string
-  stake: string
-  stake_24_hr_change: string
-  dominance: string
-  validator_stake: string
+  root_rank: number
+  alpha_rank: number
+  active_subnets: number
+  global_nominators: number
+  global_nominators_24_hr_change: number
   take: string
-  total_daily_return: string
-  validator_return: string
-  nominator_return_per_k: string
-  apr: string
-  nominator_return_per_k_7_day_average: string
-  nominator_return_per_k_30_day_average: string
-  apr_7_day_average: string
-  apr_30_day_average: string
-  pending_emission: string
-  blocks_until_next_reward: number
-  last_reward_block: number
-  registrations: number[]
-  permits: number[]
-  subnet_dominance: SubnetDominance[]
+  global_weighted_stake: string
+  global_weighted_stake_24_hr_change: string
+  global_alpha_stake_as_tao: string
+  root_stake: string
+  weighted_root_stake: string
+  dominance: string
+  dominance_24_hr_change: string
+  nominator_return_per_day: string
+  validator_return_per_day: string
 }
 
 // API Response Type
@@ -136,7 +123,6 @@ export type ValidatorsResponse = {
 export type BondOption = {
   poolId: string
   name: string
-  apr: number
   totalStaked: number
   totalStakers: number
   hasData: boolean


### PR DESCRIPTION
# Description

Updated taostats api endpoint on `useGetBittensorInfiniteValidators` hook. This new endpoint does not offer APR (for now) so any code displaying/sorting APRs has temporarily commented out and APR is being displayed as "--"

### 🖼️ **Screenshots:**

![Screenshot 2025-04-09 at 9 43 49](https://github.com/user-attachments/assets/eb3c5d6d-d60f-4f7c-bf65-df7edf950102)
