### PR TITLE
chore: updated bitensor APY copy

### DIFF
--- a/apps/portal/src/components/widgets/staking/subtensor/DelegateSelectorDialog.tsx
+++ b/apps/portal/src/components/widgets/staking/subtensor/DelegateSelectorDialog.tsx
@@ -51,7 +51,7 @@ export const DelegateSelectorDialog = (props: DelegateSelectorDialogProps) => {
   if (!hasDTaoStaking) {
     sortMethods = {
       ...sortMethods,
-      'Estimated APR': (a, b) =>
+      'Estimated APY': (a, b) =>
         parseFloat(b.props.estimatedApr?.replace('%', '') ?? '0') -
         parseFloat(a.props.estimatedApr?.replace('%', '') ?? '0'),
     }
@@ -95,7 +95,7 @@ export const DelegateSelectorDialog = (props: DelegateSelectorDialogProps) => {
             key={delegate.poolId}
             balanceDescription="Total staked with this delegate"
             countDescription="Number of delegate stakers"
-            estimatedAprDescription="Estimated APR"
+            estimatedAprDescription="Estimated APY (30d)"
             estimatedApr={!hasDTaoStaking ? formattedApr : undefined}
             talismanRecommendedDescription="Talisman top recommended delegate"
             selected={delegate.poolId === props.selected?.poolId}


### PR DESCRIPTION
## Description

Updated bittensor yield copy to APY


### 🖼️ **Screenshots:**

![Screenshot 2025-04-16 at 15 15 07](https://github.com/user-attachments/assets/f23fc7ca-c2f1-4129-9c04-cfe380a55900)
