### PR TITLE
chore: change default sort order

### DIFF
--- a/apps/portal/src/components/widgets/staking/subtensor/SubnetSelectorCard.tsx
+++ b/apps/portal/src/components/widgets/staking/subtensor/SubnetSelectorCard.tsx
@@ -27,7 +27,6 @@ export const SubnetSelectorCard = ({
   const surfaceColor = useSurfaceColor()
   const nativeTokenAmount = useRecoilValue(useNativeTokenAmountState())
   const nativeTokenDecimals = nativeTokenAmount.fromPlanckOrUndefined(0).decimalAmount?.decimals
-  console.log({ nativeTokenDecimals })
 
   const isHighlighted = highlighted || selected
   const alpha = isHighlighted ? 'high' : 'disabled'

--- a/apps/portal/src/components/widgets/staking/subtensor/SubnetSelectorCard.tsx
+++ b/apps/portal/src/components/widgets/staking/subtensor/SubnetSelectorCard.tsx
@@ -1,7 +1,8 @@
+import { BalanceFormatter } from '@talismn/balances'
 import { useSurfaceColor, useSurfaceColorAtElevation } from '@talismn/ui/atoms/Surface'
 import { Text } from '@talismn/ui/atoms/Text'
 import { Tooltip } from '@talismn/ui/atoms/Tooltip'
-import { classNames } from '@talismn/util'
+import { classNames, formatDecimals } from '@talismn/util'
 import { useRecoilValue } from 'recoil'
 
 import { useNativeTokenAmountState } from '@/domains/chains/recoils'
@@ -25,14 +26,17 @@ export const SubnetSelectorCard = ({
   const surfaceVariant = useSurfaceColorAtElevation(x => x + 1)
   const surfaceColor = useSurfaceColor()
   const nativeTokenAmount = useRecoilValue(useNativeTokenAmountState())
+  const nativeTokenDecimals = nativeTokenAmount.fromPlanckOrUndefined(0).decimalAmount?.decimals
+  console.log({ nativeTokenDecimals })
 
   const isHighlighted = highlighted || selected
   const alpha = isHighlighted ? 'high' : 'disabled'
   const { symbol, netuid, total_tao, total_alpha, descriptionName } = subnetPool
   const name = `${netuid} | ${descriptionName}`
 
-  const totalTao = nativeTokenAmount.fromPlanckOrUndefined(total_tao).decimalAmount?.toLocaleString() ?? ''
-  const totalAlpha = nativeTokenAmount.fromPlanckOrUndefined(total_alpha, symbol).decimalAmount?.toLocaleString() ?? ''
+  const totalTao = `${formatDecimals(new BalanceFormatter(total_tao, nativeTokenDecimals).tokens)} TAO`
+
+  const totalAlpha = `${formatDecimals(new BalanceFormatter(total_alpha, nativeTokenDecimals).tokens)} ${symbol}`
 
   return (
     <article

--- a/apps/portal/src/components/widgets/staking/subtensor/SubnetSelectorDialog.tsx
+++ b/apps/portal/src/components/widgets/staking/subtensor/SubnetSelectorDialog.tsx
@@ -30,12 +30,12 @@ export const SubnetSelectorDialog = ({ selected, onRequestDismiss, onConfirm }: 
       onConfirm={() => highlighted && onConfirm(highlighted)}
       isSortDisabled={isError}
       sortMethods={{
-        'Subnet UID': (a, b) => {
-          return (b.props.subnetPool.netuid ?? 0) === (a.props.subnetPool.netuid ?? 0)
+        'Total Alpha': (a, b) => {
+          return (b.props.subnetPool.total_alpha ?? 0) === (a.props.subnetPool.total_alpha ?? 0)
             ? 0
-            : (Number(b.props.subnetPool.netuid) || 0) - (Number(a.props.subnetPool.netuid) || 0) < 0
-            ? 1
-            : -1
+            : (Number(b.props.subnetPool.total_alpha) || 0) - (Number(a.props.subnetPool.total_alpha) || 0) < 0
+            ? -1
+            : 1
         },
         'Total TAO': (a, b) => {
           return (b.props.subnetPool.total_tao ?? 0) === (a.props.subnetPool.total_tao ?? 0)
@@ -44,12 +44,12 @@ export const SubnetSelectorDialog = ({ selected, onRequestDismiss, onConfirm }: 
             ? -1
             : 1
         },
-        'Total Alpha': (a, b) => {
-          return (b.props.subnetPool.total_alpha ?? 0) === (a.props.subnetPool.total_alpha ?? 0)
+        'Subnet UID': (a, b) => {
+          return (b.props.subnetPool.netuid ?? 0) === (a.props.subnetPool.netuid ?? 0)
             ? 0
-            : (Number(b.props.subnetPool.total_alpha) || 0) - (Number(a.props.subnetPool.total_alpha) || 0) < 0
-            ? -1
-            : 1
+            : (Number(b.props.subnetPool.netuid) || 0) - (Number(a.props.subnetPool.netuid) || 0) < 0
+            ? 1
+            : -1
         },
       }}
     >


### PR DESCRIPTION
# Description

- Change subnet select modal default sort order to Total Alpha
- Fix Token units wrapping into two lines, display "29k TAO" instead of "29,000.00 TAO" 

### 🖼️ **Screenshots:**

![Screenshot 2025-04-16 at 16 18 45](https://github.com/user-attachments/assets/49fe454c-5646-4e0e-a6e8-8791c5cee642)

