### PR TITLE
feat: switch to broker as a service for CF

### DIFF
--- a/apps/portal/.env.example
+++ b/apps/portal/.env.example
@@ -21,3 +21,4 @@ VITE_TAOSTATS_API_KEY=
 
 VITE_TALISMAN_BIFROST_CHANNEL_ID=4 # This is the channel ID for the bifrost channel to identify txs from Talisman
 VITE_RAMP_API_KEY=5ga4dyv63auqe9t2ytrcz8jaaudmq4m2js8egzsh
+VITE_CHAINFLIP_API_KEY=d33dfef2677849b294ec4cfb8de4d28e

--- a/apps/portal/src/components/widgets/swap/swap-modules/chainflip.swap-module.ts
+++ b/apps/portal/src/components/widgets/swap/swap-modules/chainflip.swap-module.ts
@@ -124,9 +124,9 @@ export const polkadotRpcAtom = atom(get =>
 const brokerUrlAtom = atom(get => {
   switch (get(chainflipNetworkAtom)) {
     case 'mainnet':
-      return 'https://broker.chainflip.talisman.xyz'
+      return `https://chainflip-broker.io/rpc/${import.meta.env.VITE_CHAINFLIP_API_KEY}`
     case 'perseverance':
-      return 'https://broker.perseverance.chainflip.talisman.xyz'
+      return 'https://perseverance.chainflip-broker.io/rpc/93c2bff017e243f29ffb14e42dccbec8'
     default:
       return undefined
   }
@@ -219,7 +219,6 @@ const quote: QuoteFunction = loadable(
         destAsset: chainflipToAsset.asset,
         srcChain: chainflipFromAsset.chain,
         destChain: chainflipToAsset.chain,
-        boostFeeBps: CHAINFLIP_COMMISSION_BPS,
       })
 
       const fees = quote.quote.includedFees
@@ -333,6 +332,7 @@ const swap: SwapFunction<ChainflipSwapActivityData> = async (
       destAsset: chainflipToAsset.asset,
       srcAsset: chainflipFromAsset.asset,
       srcChain: chainflipFromAsset.chain,
+      // TODO: fillOrKillParams is now required
     })
 
     // begin swap

--- a/apps/portal/src/vite-env.d.ts
+++ b/apps/portal/src/vite-env.d.ts
@@ -25,6 +25,7 @@ interface ImportMetaEnv {
   VITE_TAOSTATS_API_URL: string
   VITE_TALISMAN_BIFROST_CHANNEL_ID: string
   VITE_RAMP_API_KEY: string
+  VITE_CHAINFLIP_API_KEY: string
 }
 
 declare namespace JSX {


### PR DESCRIPTION
* Added the Talisman **Public** API key, this can be exposed.
* Switched to use it for mainnet, testnet is just the common testnet key.
* Removed `boostFeeBps` on quote, this does not exist

Remaining TODO's to make the integration work again:
* `fillOrKillParams` is now a required field.