### PR TITLE
feat: remove managed staking, display stake hotkey and tooltip

### DIFF
--- a/apps/portal/src/components/widgets/staking/subtensor/StakeItemRow.tsx
+++ b/apps/portal/src/components/widgets/staking/subtensor/StakeItemRow.tsx
@@ -1,3 +1,5 @@
+import { Tooltip } from '@talismn/ui/atoms/Tooltip'
+
 import type { Account } from '@/domains/accounts/recoils'
 import type { StakeItem } from '@/domains/staking/subtensor/hooks/useStake'
 import { StakePosition } from '@/components/recipes/StakePosition'
@@ -51,7 +53,9 @@ export const StakeItemRow = ({
   const { name = '', nativeToken: { symbol, logo } = { symbol: '', logo: '' } } = chain || {}
   const assetSymbol = isRootnetStake ? symbol : `SN${stake.netuid} ${stake.descriptionName ?? ''}`
   const assetLogo = isRootnetStake ? logo : DTAO_LOGO
-  const provider = combinedValidatorsData.find(({ poolId }) => poolId === stake.hotkey)?.name ?? 'Managed delegation'
+  const provider = combinedValidatorsData.find(({ poolId }) => poolId === stake.hotkey)?.name ?? null
+
+  const providerTooltip = <Tooltip content={stake.hotkey}>{stake.hotkey}</Tooltip>
 
   const fiatBalance = isRootnetStake ? stake.totalStaked.localizedFiatAmount : expectedTaoAmount.localizedFiatAmount
 
@@ -69,7 +73,7 @@ export const StakeItemRow = ({
         assetSymbol={assetSymbol}
         assetLogoSrc={assetLogo}
         account={account}
-        provider={provider}
+        provider={provider || providerTooltip}
         stakeStatus={'earning_rewards'}
         isError={isError}
         errorMessage={errorMessage}


### PR DESCRIPTION
# Description

Removes "Managed delegation" copy, and displays stake hotkey instead. This helps displaying the correct status and hotkey for dTao miners.

### 🖼️ **Screenshots:**
<img width="1281" height="368" alt="Screenshot 2025-08-06 at 11 27 17" src="https://github.com/user-attachments/assets/cee65e35-e6d5-4b84-aa55-b960f4fda8e2" />


